### PR TITLE
docs: establish roadmap and task backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# mercator
+# Mercator
+
+Mercator is an adaptive extraction platform that generates reusable recipes for e-commerce pages and executes them deterministically. This repository will grow into a TypeScript monorepo housing the headless service, SDK, reviewer UI, and shared agent tooling.
+
+## Getting Oriented
+
+1. Start with the [Product Vision](docs/product/vision.md) for durable goals and deliverables.
+2. Review the [System Overview](docs/architecture/system-overview.md) to understand planned components and package layout.
+3. Check the [Iteration Roadmap](docs/plan/iterations.md) to see how functionality will roll out.
+4. Pick the next task from the [Task Backlog](docs/tasks/index.md) and follow the [Task Working Agreement](docs/tasks/README.md).
+5. Consult the [Architecture Decisions](docs/decisions/README.md) for rationale behind major choices.
+
+## Contributing
+
+- Follow the task priority order; do not skip ahead without approval.
+- Update task status directly in the task tables when starting or finishing work.
+- Record new architectural choices as ADRs in `docs/decisions/`.
+- Keep documentation synchronized with implemented behavior to minimize churn.
+
+## Repository Layout (planned)
+
+```
+apps/
+  service/
+  reviewer-ui/
+packages/
+  core/
+  sdk/
+  agent-tools/
+fixtures/
+```
+
+Actual directories will be created as tasks in Iteration I01 are completed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Mercator Documentation
+
+This folder captures the stable product vision, architecture, and delivery plan for the Mercator project.
+
+## Document Map
+
+- [Product Vision](product/vision.md) – durable goals and scope that rarely change.
+- [Architecture Overview](architecture/system-overview.md) – core components, agents, and interfaces.
+- [Delivery Plan](plan/iterations.md) – iteration roadmap and feature sequencing.
+- [Task Backlog](tasks/index.md) – actionable work items grouped by iteration/feature.
+- [Decisions](decisions/README.md) – architecture decision records (ADRs) for key choices.
+
+When adding new documentation, prefer updating the most specific file instead of duplicating information. Link related docs to keep navigation simple for future agents.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -1,0 +1,61 @@
+# System Overview
+
+Mercator is delivered as a TypeScript monorepo that houses four primary products sharing a unified recipe abstraction.
+
+```
+apps/
+  service/        # REST + CLI entrypoints (Docker target)
+  reviewer-ui/    # HITL tri-pane application
+packages/
+  sdk/            # @mercator/sdk client package
+  core/           # shared domain models, recipe engine, transforms, tolerances
+  agent-tools/    # query/vision tool shims exposed to the agent loop
+```
+
+## Core Components
+
+### 1. Agent Orchestration Loop
+- **Coordinator** manages the multi-pass workflow (vision → HTML retrieval → reconciliation) and enforces budgets/stopping criteria.
+- **User Proxy, Extractor, Validator, Reviewer, Storage** agents share a typed context and communicate through deterministically logged tool invocations.
+- **Tool layer** exposes screenshot OCR, chunked HTML queries, JSON-LD extraction, transform catalog lookups, and provenance recording.
+
+### 2. Recipe Abstraction
+- Single schema representing selector, Playwright, or hybrid extraction strategies.
+- Fields include steps, transforms, validators, tolerances, provenance, metrics, lifecycle state, and version metadata.
+- Stored in the **Recipe Store** with pluggable adapters (`LocalFS`, `S3`, `KV`).
+
+### 3. Execution Engine
+- Deterministic runner that applies a promoted recipe to HTML/markdown inputs.
+- Uses shared transform & validation libraries to normalize output and compute confidence.
+- Enforced separation from generation path; no AI or agent interaction during execution.
+
+### 4. Service & CLI
+- REST endpoints (`/recipes/generate`, `/recipes/test`, `/recipes/promote`, `/parse`, `/review/submit`) expose orchestration and lifecycle operations.
+- CLI mirrors service operations for local workflows and testing.
+- Docker image bundles the service with recipe store adapters and policy configuration.
+
+### 5. Reviewer UI
+- Tri-pane interface displaying screenshot overlays, DOM snippets, and JSON diffs.
+- Supports approval/regression, tolerance adjustments, and provenance review.
+- Communicates with the service via authenticated APIs.
+
+### 6. SDK (`@mercator/sdk`)
+- Client for recipe execution and lifecycle operations.
+- Provides TypeScript types (Zod schemas), parse helpers, and recipe validation utilities.
+- Published to npm with generated API docs.
+
+## Cross-Cutting Concerns
+
+- **Policy Gate** – central module controlling Playwright usage, robots/TOS compliance, tenant-specific limits, and logging denials.
+- **Observability** – metrics pipeline capturing coverage, confidence, latency, token/query budgets, promotion funnel, and rollback alerts.
+- **Transform Sandbox** – deterministic transform execution with no network or filesystem side effects; namespaced builtins vs custom transforms.
+- **Data Retention & Audit** – artifact storage (screenshots, HTML, JSON) with retention windows and access controls.
+
+## Architectural Principles
+
+1. **Thin vertical slices** – every iteration delivers an end-to-end scenario touching agents, recipe compilation, validation, review, and execution.
+2. **Composable services** – share logic through packages; keep apps lightweight adapters.
+3. **Deterministic interfaces** – all agent tool calls and recipe executions are deterministic and loggable, enabling replay and regression tests.
+4. **Extensibility** – adapters for storage, policies, and tools use dependency injection so new backends can be added without rewriting workflows.
+
+Detailed iteration plans, component boundaries, and task-level work are tracked in the delivery and task documents.

--- a/docs/decisions/0001-monorepo-tech-stack.md
+++ b/docs/decisions/0001-monorepo-tech-stack.md
@@ -1,0 +1,22 @@
+# ADR 0001 – Monorepo Tech Stack
+
+## Status
+Proposed – review before starting Iteration I01 scaffolding work.
+
+## Context
+Mercator must deliver a headless service, SDK, shared core libraries, agent tooling, and a reviewer UI. These components need shared type safety (Zod schemas), consistent build tooling, and straightforward local development. The PRD emphasizes lean vertical slices with rapid iteration across these deliverables.
+
+## Decision
+Adopt a **TypeScript monorepo** managed with **pnpm workspaces**. Organize the repository with top-level `apps/` (service, reviewer UI) and `packages/` (core domain logic, SDK, agent tools, shared utilities). Centralize TypeScript configuration, linting, and testing at the workspace root. Publishable packages (e.g., `@mercator/sdk`) will be versioned via pnpm workspaces and prepared for npm publishing from the same repo.
+
+## Rationale
+- Shared TypeScript types and Zod schemas can be imported across service, SDK, and UI without duplication.
+- pnpm offers fast installs, deterministic lockfiles, and built-in workspace linking suitable for agents and CI pipelines.
+- Monorepo layout simplifies orchestrating thin vertical slices touching multiple products in a single change.
+- Keeping tooling consistent reduces ramp-up for new agents and supports automated checks.
+
+## Consequences
+- Requires initial investment in workspace configuration (captured in task `I01-F1-T1`).
+- CI must understand pnpm caching strategies; addressed in task `I01-F1-T2`.
+- Publishing flows need scripts to build individual packages without dragging in server-only dependencies.
+- Future ADRs should revisit this choice if scale or tooling constraints emerge (e.g., need for Bazel/Nx).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,9 @@
+# Architecture Decisions
+
+Important technical choices are recorded as Architecture Decision Records (ADRs) so future contributors understand rationale and trade-offs. Create new ADRs in this folder using the naming pattern `NNNN-title.md`.
+
+## Index
+
+- [0001-monorepo-tech-stack.md](0001-monorepo-tech-stack.md) – Establishes the TypeScript/pnpm workspace approach and package layout.
+
+Update the index whenever new ADRs are added.

--- a/docs/plan/iterations.md
+++ b/docs/plan/iterations.md
@@ -1,0 +1,14 @@
+# Iteration Roadmap
+
+Mercator evolves through thin vertical slices. Each iteration delivers a usable increment while laying foundations for the next step. Iteration documents should be updated when scope or acceptance criteria change; completed iterations remain as historical records.
+
+| ID | Status  | Focus | Key Outcomes |
+|----|---------|-------|--------------|
+| I01 | Planned | **MVP Product Page Loop** | Agent-assisted recipe generation on synthetic product fixtures, deterministic execution path, CLI/REST thin slice, reviewer workflow stub. |
+| I02 | Planned | **Real Product Pages & Canarying** | Introduce curated live URLs, canary vs stable comparison, budget tracking, improved observability. |
+| I03 | Planned | **Collection Pages & Pagination** | Extend schemas/agents to handle collection cards, pagination sampling, tolerance strategies for partial visibility. |
+| I04 | Planned | **Reviews & Interactivity** | Handle review sections with bounded Playwright plans or API usage, revisit queue for partial sections. |
+| I05 | Planned | **Playwright-first Domains & Variants** | Policy-gated Playwright generation, variant/offer modeling, transform catalog expansion. |
+| I06 | Planned | **Agent Review & Governance** | Transition stable domains to agent review, add dashboards, recipe aging triggers, tenant isolation. |
+
+Detailed task breakdowns live in `docs/tasks`. Each iteration file (e.g., `iteration-01-mvp.md`) captures scope, milestones, and acceptance tests.

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -1,0 +1,35 @@
+# Product Vision
+
+Mercator delivers clean, validated product and collection data from any e-commerce page through an adaptive agent-assisted workflow. The service must remain extraction-method agnostic while producing reusable recipes that can be executed deterministically without large language models.
+
+## Durable Goals
+
+- **Recipe-first extraction** – Generate reusable selector/Playwright/hybrid recipes during an agent-driven assessment loop, then execute them without AI involvement.
+- **High-confidence page understanding** – Detect product vs collection pages with provenance and confidence scoring, and guard critical fields (`title`, `price`) with strict tolerances.
+- **End-to-end workflow coverage** – Support recipe generation, validation, review (HITL transitioning to agent review), promotion, reuse, and rollback.
+- **Human-in-the-loop quality** – Provide reviewer tools and audit trails so humans or agents can approve, regress, or escalate recipes safely.
+- **Observability & governance** – Capture metrics (coverage, confidence, latency, budget) and respect policy/tenant isolation, robots/TOS, and transform sandboxing.
+
+## Key Deliverables
+
+- **Mercator Service** – Headless REST/CLI service packaged for Docker deployments.
+- **Mercator SDK (`@mercator/sdk`)** – TypeScript package exposing parse and recipe APIs.
+- **Recipe Store** – Pluggable persistence (local FS, S3/KV) with recipe lifecycle metadata.
+- **Reviewer UI** – Tri-pane review experience runnable locally or behind auth.
+
+## Core Workflow Objectives
+
+1. **Agent-driven assessment** – Multi-pass loop that starts from screenshot/vision, augments via chunked HTML/markdown queries, reconciles evidence, and compiles candidate recipes within budget.
+2. **Unified recipe abstraction** – Single format capturing selectors, Playwright code, transforms, tolerances, validators, metrics, and lifecycle state.
+3. **Validation & scoring** – Schema-centric models (Zod) with tolerance policies, evidence matrices, and document confidence computation.
+4. **Lifecycle management** – Promotion states (`draft → candidate → canary → stable → retired`), A/B canary testing, rollback safeguards, and provenance history.
+5. **Lean iteration** – Ship thin vertical slices that exercise the full loop before expanding scope (products first, collections later).
+
+## Non-Negotiable Policies
+
+- Separate **generation** (AI-assisted) from **execution** (deterministic recipe run).
+- Enforce **budget limits** (queries, time) and **policy gates** (Playwright allowance, robots compliance).
+- Maintain **sandboxed transforms** with deterministic behavior and no network side effects.
+- Preserve **auditability**: reviewer decisions, metrics, artifacts retained per policy.
+
+This vision document should remain stable. Update only when business goals or success criteria change materially; iteration-specific plans belong in the delivery documents.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,10 @@
+# Task Working Agreement
+
+- **Source of truth** – Tasks live under `docs/tasks`. Do not duplicate requirements elsewhere. Update statuses directly in the task tables.
+- **Statuses** – Use `Todo`, `In Progress`, `Blocked`, or `Done`. Leave tasks in `Todo` unless you are actively working on them.
+- **Picking work** – Start with the earliest iteration that still has `Todo` tasks. Within an iteration, follow the priority order listed in each feature table.
+- **Dependencies** – Respect the `Depends On` column before starting a task. If a dependency is unclear, clarify it in the task notes rather than proceeding.
+- **Scope changes** – If you uncover missing work, create a new task with a clear description and link it from the `Notes` field. Avoid editing higher-level docs unless the product direction changes.
+- **Deliverables** – Every task specifies the expected artifacts (code, tests, docs). Use them as acceptance criteria for PR reviews.
+
+When closing a task, add a brief changelog link or PR number in the `Notes` column for traceability.

--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -1,0 +1,13 @@
+# Task Backlog Index
+
+Tasks are grouped by iteration and feature area. Always pick work from the earliest iteration that still has unfinished tasks unless a maintainer explicitly reprioritizes.
+
+1. Review the [Task Working Agreement](README.md) to understand status updates and contribution etiquette.
+2. Open the relevant iteration file below and choose the first **`Todo`** task in priority order. Update the status to `In Progress` when you start and `Done` once your PR is merged.
+
+| Iteration | Status | Task File |
+|-----------|--------|-----------|
+| I01 – MVP Product Page Loop | Planned | [iteration-01-mvp.md](iteration-01-mvp.md) |
+| I02 – Live Products & Canarying | Draft | [iteration-02-live-products.md](iteration-02-live-products.md) |
+
+If new work is discovered, add it as a task in the appropriate iteration with clear dependencies rather than editing vision or architecture docs.

--- a/docs/tasks/iteration-01-mvp.md
+++ b/docs/tasks/iteration-01-mvp.md
@@ -1,0 +1,70 @@
+# Iteration I01 — MVP Product Page Loop
+
+## Goal
+Deliver a deterministic end-to-end slice that generates, validates, reviews, stores, and executes a selector-based recipe for the synthetic product fixture. All work should reinforce the separation between the AI-assisted generation path and the deterministic execution path.
+
+## Milestones
+
+1. **Scaffold** – Monorepo + core packages with schemas, recipe model, and fixtures ready.
+2. **Loop** – Agent orchestration stub that consumes fixture inputs and produces a candidate selector recipe.
+3. **Execution** – Service/CLI route that executes the promoted recipe without AI, returning validated JSON.
+4. **Quality Gate** – Unit tests for transforms/tolerances and an end-to-end test covering generation vs execution on the fixture.
+
+## Feature Backlog
+
+Priority is ascending within each feature. Always complete lower-numbered tasks before moving to higher numbers unless explicitly re-ordered.
+
+### F1. Repository Foundation & Tooling
+
+| Priority | Task ID | Description | Deliverables | Depends On | Status | Notes |
+|----------|---------|-------------|--------------|------------|--------|-------|
+| 1 | I01-F1-T1 | Bootstrap pnpm workspace with `apps/` and `packages/` folders, TypeScript config, lint/test scripts, and shared tsconfig/eslint/prettier configs. | pnpm workspace config, root `package.json`, lint/test npm scripts, baseline README updates. | — | Todo |  |
+| 2 | I01-F1-T2 | Configure basic CI (GitHub Actions) running lint and tests; document local dev commands. | `.github/workflows/ci.yml`, docs update in README. | I01-F1-T1 | Todo | Optional skip if CI unavailable; document rationale. |
+
+### F2. Core Domain & Recipe Schema
+
+| Priority | Task ID | Description | Deliverables | Depends On | Status | Notes |
+|----------|---------|-------------|--------------|------------|--------|-------|
+| 1 | I01-F2-T1 | Create `packages/core` with TypeScript models + Zod schemas for Product (subset needed for MVP), Money, Breadcrumb, and supporting types per Appendix A. | `packages/core/src/schemas.ts`, unit tests validating schema behavior. | I01-F1-T1 | Todo | Keep scope to MVP-required fields (title, price, image, canonicalUrl, breadcrumb, aggregateRating). |
+| 2 | I01-F2-T2 | Define unified recipe schema (TypeScript + Zod) capturing selector steps, transforms, tolerances, validators, metrics, lifecycle metadata. | `packages/core/src/recipe.ts`, schema tests ensuring optional Playwright fields for later iterations. | I01-F2-T1 | Todo | Base tolerances on Appendix B defaults. |
+| 3 | I01-F2-T3 | Record default tolerance + transform configs and expose typed helpers. | `packages/core/src/tolerances.ts`, `transforms.ts`, tests for `text.collapse`, `money.parse`, `url.resolve`. | I01-F2-T2 | Todo | Include deterministic behavior & locale assumptions docstring. |
+
+### F3. Fixtures & Tool Surface
+
+| Priority | Task ID | Description | Deliverables | Depends On | Status | Notes |
+|----------|---------|-------------|--------------|------------|--------|-------|
+| 1 | I01-F3-T1 | Add synthetic product fixture assets (HTML, markdown, screenshot) and loader utilities. | `fixtures/product-simple.html`, `.md`, `.png`, loader module exporting typed accessors. | I01-F1-T1 | Todo | Document fixture structure & expected values in `docs/fixtures/product-simple.md`. |
+| 2 | I01-F3-T2 | Implement minimal agent tool interfaces for vision OCR stub, chunked HTML queries, markdown search returning deterministic data from fixtures. | `packages/agent-tools/src/index.ts`, stub implementations referencing fixtures. | I01-F3-T1, I01-F2-T2 | Todo | Tools should log usage for later observability. |
+
+### F4. Agent Orchestration Slice
+
+| Priority | Task ID | Description | Deliverables | Depends On | Status | Notes |
+|----------|---------|-------------|--------------|------------|--------|-------|
+| 1 | I01-F4-T1 | Define agent context contracts and orchestrator skeleton covering Pass 1–3 with stubbed agents producing ExpectedData and candidate recipe steps. | `packages/core/src/agents/` (interfaces), orchestrator in `apps/service` or shared package, unit tests for control flow. | I01-F2-T2, I01-F3-T2 | Todo | Use deterministic prompts/stubs; no LLM calls. |
+| 2 | I01-F4-T2 | Implement selector recipe synthesis for fixture (map expected fields to CSS selectors, apply transforms/tolerances). | Module producing recipe object, tests verifying selectors match fixture DOM. | I01-F4-T1 | Todo | Capture provenance/evidence matrix structure even if stubbed. |
+| 3 | I01-F4-T3 | Implement validator pass computing per-field/document confidence using tolerance helpers and Zod. | Validation module + tests verifying success/failure cases for fixture variations. | I01-F4-T2, I01-F2-T3 | Todo | Include enforcement of stopping criteria for title/price. |
+
+### F5. Service, CLI & Recipe Store
+
+| Priority | Task ID | Description | Deliverables | Depends On | Status | Notes |
+|----------|---------|-------------|--------------|------------|--------|-------|
+| 1 | I01-F5-T1 | Implement LocalFS-backed recipe store with versioned state machine (`draft → stable`). | Store module + tests covering save/promote/list. | I01-F2-T2 | Todo | Prepare adapter pattern for future stores. |
+| 2 | I01-F5-T2 | Create REST + CLI endpoints for `/recipes/generate`, `/recipes/promote`, `/parse` wired to orchestrator and recipe store. | Service handlers, CLI commands, integration test hitting fixture path. | I01-F4-T3, I01-F5-T1 | Todo | CLI should call same underlying services to avoid drift. |
+| 3 | I01-F5-T3 | Add reviewer stub endpoint returning tri-pane payload (screenshot, DOM snippet, JSON diff) for HITL. | Endpoint returning deterministic fixture data + placeholder UI data contract. | I01-F5-T2 | Todo | Document UI contract for later implementation. |
+
+### F6. Testing & Observability Baseline
+
+| Priority | Task ID | Description | Deliverables | Depends On | Status | Notes |
+|----------|---------|-------------|--------------|------------|--------|-------|
+| 1 | I01-F6-T1 | Write unit tests for transforms, tolerances, and recipe schema invariants. | Test suite covering success/failure cases. | I01-F2-T3 | Todo | Add snapshot tests for tolerance normalization. |
+| 2 | I01-F6-T2 | Implement `E2E-Gen` and `E2E-Exec` tests covering full loop on synthetic fixture. | Integration tests verifying recipe generation/execution parity and determinism. | I01-F4-T3, I01-F5-T2 | Todo | Include budget assertions and evidence matrix checks. |
+| 3 | I01-F6-T3 | Instrument minimal metrics logging (query counts, duration) and expose via structured logs. | Logging utility, doc snippet on metrics interpretation. | I01-F4-T1 | Todo | Metrics stored locally for now; later iterations add exporters. |
+
+## Acceptance Criteria
+
+- Generation pipeline produces a selector-based recipe for the synthetic fixture with populated `title`, `price`, `images[0]`, `canonicalUrl`, `aggregateRating?`, and `breadcrumb` when available.
+- `/parse` endpoint/CLI command executes the stable recipe without invoking agents/LLMs and returns data passing schema validation.
+- Unit and E2E tests cover core transforms, tolerance policies, recipe lifecycle, and full loop success.
+- Logs capture tool usage counts and elapsed time per pass.
+
+Document open questions or follow-up work in `Notes` fields or create new tasks for future iterations.

--- a/docs/tasks/iteration-02-live-products.md
+++ b/docs/tasks/iteration-02-live-products.md
@@ -1,0 +1,22 @@
+# Iteration I02 — Live Product Pages & Canarying (Draft)
+
+Status: **Draft** – Do not start until Iteration I01 is complete and reviewed. Update this file with refined scope once MVP learnings are available.
+
+## Tentative Objectives
+
+- Run the generation/validation loop against a curated set of live product URLs with varying complexity.
+- Introduce canary testing comparing candidate recipes to the current stable recipe.
+- Track budget utilization (query counts, latency) and surface in logs/metrics.
+- Harden policy gates (Playwright allowance, robots compliance) and observability hooks.
+
+## Draft Feature Backlog (subject to change)
+
+| Priority | Task ID | Description | Depends On | Status | Notes |
+|----------|---------|-------------|------------|--------|-------|
+| 1 | I02-F1-T1 | Collect 10–15 deterministic live product URLs with stored snapshots (HTML, screenshot) and document expected outputs. | Completion review of I01 | Todo | Requires compliance review. |
+| 2 | I02-F1-T2 | Extend fixture loader to support remote fetch with caching and policy checks. | I02-F1-T1 | Todo | Ensure robots.txt respected. |
+| 3 | I02-F2-T1 | Implement canary runner comparing candidate vs stable recipes with coverage/confidence metrics. | I01-F5-T2 | Todo | Output promotion decision rationale. |
+| 4 | I02-F2-T2 | Surface budget + confidence metrics via structured logs and optional JSON report. | I01-F6-T3 | Todo | Feed into reviewer UI later. |
+| 5 | I02-F3-T1 | Harden policy gate to record Playwright allowance per domain and fallback reasons. | I01-F5-T2 | Todo | No Playwright execution yet; just logging. |
+
+Revisit and expand these tasks after closing Iteration I01.


### PR DESCRIPTION
## Summary
- capture the durable product vision and system architecture in docs
- outline the iteration roadmap with backlog management instructions
- create detailed iteration I01 task breakdown plus draft planning for I02 and record monorepo ADR

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c994bd4bfc832cb6b15484c4c76ae6