### PR TITLE
Add CI workflow for linting and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint-and-test:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.5.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run lint
+        run: pnpm lint
+
+      - name: Run tests
+        run: pnpm test

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ The root `package.json` exposes shared scripts:
 | `pnpm format` | Verify formatting with Prettier. |
 | `pnpm dev:agents` | Start the Mastra development playground for the service app. |
 
+## Continuous Integration
+
+Run the lint and test scripts locally before opening a pull request to mirror continuous integration expectations:
+
+```bash
+pnpm lint
+pnpm test
+```
+
+GitHub Actions runs the same commands on every push and pull request via `.github/workflows/ci.yml`.
+
 Each package or app can add additional scripts that are executed via `pnpm --filter`.
 
 ## Repository Layout

--- a/docs/tasks/iteration-01-mvp.md
+++ b/docs/tasks/iteration-01-mvp.md
@@ -19,7 +19,7 @@ Priority is ascending within each feature. Always complete lower-numbered tasks 
 | Priority | Task ID | Description | Deliverables | Depends On | Status | Notes |
 |----------|---------|-------------|--------------|------------|--------|-------|
 | 1 | I01-F1-T1 | Bootstrap pnpm workspace with `apps/` and `packages/` folders, TypeScript config, lint/test scripts, and shared tsconfig/eslint/prettier configs. | pnpm workspace config, root `package.json`, lint/test npm scripts, baseline README updates. | — | Done | Set up pnpm workspace plus Mastra service app scaffolding. |
-| 2 | I01-F1-T2 | Configure basic CI (GitHub Actions) running lint and tests; document local dev commands. | `.github/workflows/ci.yml`, docs update in README. | I01-F1-T1 | Todo | Optional skip if CI unavailable; document rationale. |
+| 2 | I01-F1-T2 | Configure basic CI (GitHub Actions) running lint and tests; document local dev commands. | `.github/workflows/ci.yml`, docs update in README. | I01-F1-T1 | Done | Optional skip if CI unavailable; document rationale. |
 
 ### F2. Core Domain & Recipe Schema
 


### PR DESCRIPTION
## Summary
- add a CI workflow that installs dependencies with pnpm and runs linting and tests on pushes and pull requests
- document the lint and test commands in the README so contributors can mirror CI locally
- mark task I01-F1-T2 as done in the iteration backlog to reflect completion of the CI work

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ac02c464832cb6804a699c8ff716