### PR TITLE
feat: add core product domain schemas

### DIFF
--- a/docs/tasks/iteration-01-mvp.md
+++ b/docs/tasks/iteration-01-mvp.md
@@ -25,7 +25,7 @@ Priority is ascending within each feature. Always complete lower-numbered tasks 
 
 | Priority | Task ID | Description | Deliverables | Depends On | Status | Notes |
 |----------|---------|-------------|--------------|------------|--------|-------|
-| 1 | I01-F2-T1 | Create `packages/core` with TypeScript models + Zod schemas for Product (subset needed for MVP), Money, Breadcrumb, and supporting types per Appendix A. | `packages/core/src/schemas.ts`, unit tests validating schema behavior. | I01-F1-T1 | Todo | Keep scope to MVP-required fields (title, price, image, canonicalUrl, breadcrumb, aggregateRating). |
+| 1 | I01-F2-T1 | Create `packages/core` with TypeScript models + Zod schemas for Product (subset needed for MVP), Money, Breadcrumb, and supporting types per Appendix A. | `packages/core/src/schemas.ts`, unit tests validating schema behavior. | I01-F1-T1 | Done | Initial `@mercator/core` domain schemas and tests. |
 | 2 | I01-F2-T2 | Define unified recipe schema (TypeScript + Zod) capturing selector steps, transforms, tolerances, validators, metrics, lifecycle metadata. | `packages/core/src/recipe.ts`, schema tests ensuring optional Playwright fields for later iterations. | I01-F2-T1 | Todo | Base tolerances on Appendix B defaults. |
 | 3 | I01-F2-T3 | Record default tolerance + transform configs and expose typed helpers. | `packages/core/src/tolerances.ts`, `transforms.ts`, tests for `text.collapse`, `money.parse`, `url.resolve`. | I01-F2-T2 | Todo | Include deterministic behavior & locale assumptions docstring. |
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@mercator/core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "lint": "eslint src --ext .ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.25.3"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,1 @@
+export * from './schemas.js';

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AggregateRatingSchema,
+  BreadcrumbSchema,
+  MoneySchema,
+  ProductSchema
+} from './schemas.js';
+
+describe('MoneySchema', () => {
+  it('normalizes currency codes and applies defaults', () => {
+    const parsed = MoneySchema.parse({ amount: 19.99, currencyCode: 'usd' });
+
+    expect(parsed).toEqual({ amount: 19.99, currencyCode: 'USD', precision: 2 });
+  });
+
+  it('rejects invalid currencies or negative amounts', () => {
+    const invalidCurrency = MoneySchema.safeParse({ amount: 10, currencyCode: 'US' });
+    const invalidAmount = MoneySchema.safeParse({ amount: -1, currencyCode: 'USD' });
+
+    expect(invalidCurrency.success).toBe(false);
+    expect(invalidAmount.success).toBe(false);
+  });
+});
+
+describe('BreadcrumbSchema', () => {
+  it('trims labels and accepts optional URLs', () => {
+    const breadcrumb = BreadcrumbSchema.parse({
+      label: '  Shoes  ',
+      url: 'https://example.com/shoes'
+    });
+
+    expect(breadcrumb).toEqual({ label: 'Shoes', url: 'https://example.com/shoes' });
+  });
+});
+
+describe('AggregateRatingSchema', () => {
+  it('validates rating bounds relative to best and worst values', () => {
+    const valid = AggregateRatingSchema.safeParse({
+      ratingValue: 4.5,
+      reviewCount: 120,
+      bestRating: 5,
+      worstRating: 1
+    });
+    const invalid = AggregateRatingSchema.safeParse({
+      ratingValue: 6,
+      bestRating: 5
+    });
+
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
+  });
+});
+
+describe('ProductSchema', () => {
+  it('parses a minimal MVP product payload', () => {
+    const parsed = ProductSchema.parse({
+      id: 'sku-123',
+      title: '  Sample Product  ',
+      canonicalUrl: 'https://example.com/products/sample',
+      price: { amount: 42, currencyCode: 'usd' },
+      images: ['https://example.com/assets/sample.jpg'],
+      aggregateRating: {
+        ratingValue: 4.7,
+        reviewCount: 32,
+        bestRating: 5,
+        worstRating: 1
+      },
+      breadcrumbs: [
+        { label: ' Home ', url: 'https://example.com' },
+        { label: ' Shoes ', url: 'https://example.com/shoes' }
+      ]
+    });
+
+    expect(parsed.title).toBe('Sample Product');
+    expect(parsed.price.currencyCode).toBe('USD');
+    expect(parsed.images).toEqual(['https://example.com/assets/sample.jpg']);
+    expect(parsed.breadcrumbs?.[0].label).toBe('Home');
+  });
+
+  it('rejects products without images or with empty breadcrumbs', () => {
+    const missingImages = ProductSchema.safeParse({
+      title: 'Widget',
+      canonicalUrl: 'https://example.com/widget',
+      price: { amount: 10, currencyCode: 'usd' },
+      images: []
+    });
+
+    const emptyBreadcrumbs = ProductSchema.safeParse({
+      title: 'Widget',
+      canonicalUrl: 'https://example.com/widget',
+      price: { amount: 10, currencyCode: 'usd' },
+      images: ['https://example.com/widget.jpg'],
+      breadcrumbs: []
+    });
+
+    expect(missingImages.success).toBe(false);
+    expect(emptyBreadcrumbs.success).toBe(false);
+  });
+});

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,0 +1,119 @@
+import { z } from 'zod';
+
+const ISO_4217_CURRENCY_CODE = /^[A-Z]{3}$/;
+
+const nonEmptyString = z.string().trim().min(1, 'Value must not be empty');
+const urlSchema = z.string().url();
+
+export const CurrencyCodeSchema = z
+  .string()
+  .trim()
+  .transform((value) => value.toUpperCase())
+  .refine((value) => ISO_4217_CURRENCY_CODE.test(value), {
+    message: 'Currency code must be a valid ISO 4217 alpha code'
+  });
+
+export const MoneySchema = z
+  .object({
+    amount: z
+      .number({ required_error: 'Amount is required' })
+      .finite()
+      .min(0, { message: 'Amount cannot be negative' }),
+    currencyCode: CurrencyCodeSchema,
+    precision: z
+      .number()
+      .int({ message: 'Precision must be an integer' })
+      .min(0, { message: 'Precision cannot be negative' })
+      .max(4, { message: 'Precision must be 4 or fewer decimal places' })
+      .default(2),
+    raw: z.string().trim().min(1).optional()
+  })
+  .strict();
+
+export type CurrencyCode = z.infer<typeof CurrencyCodeSchema>;
+export type Money = z.infer<typeof MoneySchema>;
+
+export const BreadcrumbSchema = z
+  .object({
+    label: nonEmptyString,
+    url: urlSchema.optional(),
+    position: z
+      .number()
+      .int({ message: 'Position must be an integer' })
+      .min(1, { message: 'Position must start at 1' })
+      .optional()
+  })
+  .strict();
+
+export type Breadcrumb = z.infer<typeof BreadcrumbSchema>;
+
+export const AggregateRatingSchema = z
+  .object({
+    ratingValue: z
+      .number({ required_error: 'ratingValue is required' })
+      .finite()
+      .min(0, { message: 'ratingValue cannot be negative' })
+      .max(5, { message: 'ratingValue cannot be greater than 5' }),
+    reviewCount: z
+      .number()
+      .int({ message: 'reviewCount must be an integer' })
+      .min(0, { message: 'reviewCount cannot be negative' })
+      .optional(),
+    bestRating: z
+      .number()
+      .finite()
+      .min(0, { message: 'bestRating cannot be negative' })
+      .optional(),
+    worstRating: z
+      .number()
+      .finite()
+      .min(0, { message: 'worstRating cannot be negative' })
+      .optional(),
+    url: urlSchema.optional()
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.bestRating === undefined ||
+      value.worstRating === undefined ||
+      value.bestRating > value.worstRating,
+    {
+      message: 'bestRating must be greater than worstRating'
+    }
+  )
+  .refine(
+    (value) => value.bestRating === undefined || value.ratingValue <= value.bestRating,
+    {
+      message: 'ratingValue must be less than or equal to bestRating'
+    }
+  )
+  .refine(
+    (value) => value.worstRating === undefined || value.ratingValue >= value.worstRating,
+    {
+      message: 'ratingValue must be greater than or equal to worstRating'
+    }
+  );
+
+export type AggregateRating = z.infer<typeof AggregateRatingSchema>;
+
+export const ProductSchema = z
+  .object({
+    id: nonEmptyString.optional(),
+    title: nonEmptyString,
+    canonicalUrl: urlSchema,
+    description: z.string().trim().optional(),
+    price: MoneySchema,
+    images: z.array(urlSchema).min(1, { message: 'At least one product image is required' }).readonly(),
+    thumbnail: urlSchema.optional(),
+    aggregateRating: AggregateRatingSchema.optional(),
+    breadcrumbs: z
+      .array(BreadcrumbSchema)
+      .min(1, { message: 'Provide at least one breadcrumb when breadcrumbs are supplied' })
+      .readonly()
+      .optional(),
+    brand: nonEmptyString.optional(),
+    sku: nonEmptyString.optional()
+  })
+  .strict();
+
+export type Product = z.infer<typeof ProductSchema>;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,12 @@ importers:
         specifier: ^5.6.3
         version: 5.9.2
 
+  packages/core:
+    dependencies:
+      zod:
+        specifier: ^3.25.3
+        version: 3.25.76
+
 packages:
 
   '@a2a-js/sdk@0.2.5':
@@ -2630,7 +2636,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   local-pkg@1.1.2:


### PR DESCRIPTION
## Summary
- scaffold the private `@mercator/core` workspace package and expose shared schemas
- implement Zod models for money, breadcrumbs, aggregate ratings, and the MVP product payload
- add unit tests and mark the corresponding backlog task as complete

## Testing
- pnpm lint
- pnpm test
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68caaf5c35d0832ca4bac053b4e5bcae