### PR TITLE
feat: add recipe schema and defaults

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,4 @@
+export * from './recipe.js';
 export * from './schemas.js';
+export * from './tolerances.js';
+export * from './transforms.js';

--- a/packages/core/src/recipe.test.ts
+++ b/packages/core/src/recipe.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import { RecipeSchema, hasField } from './recipe.js';
+import { getDefaultTolerance } from './tolerances.js';
+import { applyTransform, getDefaultTransformOptions } from './transforms.js';
+
+describe('RecipeSchema', () => {
+  const now = new Date().toISOString();
+
+  it('parses selector recipes with optional Playwright directives', () => {
+    const recipe = RecipeSchema.parse({
+      id: 'recipe-001',
+      name: 'Fixture Product',
+      version: '1.0.0',
+      createdAt: now,
+      updatedAt: now,
+      target: {
+        documentType: 'product',
+        schema: {
+          id: 'sku-1',
+          title: 'Fixture Product',
+          canonicalUrl: 'https://example.com/products/fixture',
+          price: { amount: 19.99, currencyCode: 'USD' },
+          images: ['https://example.com/assets/fixture.jpg']
+        },
+        fields: [
+          {
+            fieldId: 'title',
+            selectorSteps: [{ strategy: 'css', value: 'h1.product-title' }],
+            transforms: [{ name: 'text.collapse' }],
+            tolerance: getDefaultTolerance('title'),
+            validators: [{ type: 'required' }],
+            metrics: { sampleCount: 3, passCount: 3, failCount: 0 }
+          },
+          {
+            fieldId: 'images',
+            selectorSteps: [
+              {
+                strategy: 'css',
+                value: '.gallery img',
+                attribute: 'src',
+                playwright: { action: 'waitForSelector', selector: '.gallery img' }
+              }
+            ],
+            transforms: [
+              {
+                name: 'url.resolve',
+                options: { baseUrl: 'https://example.com/products/fixture' }
+              }
+            ],
+            tolerance: getDefaultTolerance('images'),
+            validators: [{ type: 'minLength', value: 1 }]
+          }
+        ]
+      },
+      lifecycle: {
+        state: 'draft',
+        since: now,
+        history: [{ state: 'draft', at: now, actor: 'agent' }]
+      },
+      metrics: { totalRuns: 1, successfulRuns: 1 },
+      provenance: [
+        { fieldId: 'title', evidence: 'css:h1.product-title', confidence: 0.9 }
+      ]
+    });
+
+    expect(recipe.target.fields).toHaveLength(2);
+    expect(hasField(recipe, 'price')).toBe(false);
+    expect(recipe.lifecycle.history[0]?.actor).toBe('agent');
+  });
+
+  it('rejects field definitions without selector steps', () => {
+    const result = RecipeSchema.safeParse({
+      name: 'Invalid Recipe',
+      version: '0.0.1',
+      createdAt: now,
+      updatedAt: now,
+      target: {
+        documentType: 'product',
+        schema: {
+          title: 'Example',
+          canonicalUrl: 'https://example.com/products/example',
+          price: { amount: 10, currencyCode: 'USD' },
+          images: ['https://example.com/image.jpg']
+        },
+        fields: []
+      },
+      lifecycle: { state: 'draft', since: now }
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('default helpers', () => {
+  it('returns defensive copies for transform defaults', () => {
+    const baseline = getDefaultTransformOptions('text.collapse');
+    baseline.trim = false;
+
+    const second = getDefaultTransformOptions('text.collapse');
+    expect(second.trim).toBe(true);
+  });
+
+  it('returns defensive copies for tolerance defaults', () => {
+    const tolerance = getDefaultTolerance('title');
+    if (tolerance.kind !== 'text') {
+      throw new Error('Unexpected tolerance kind');
+    }
+
+    tolerance.caseSensitive = true;
+    const next = getDefaultTolerance('title');
+
+    expect(next.kind).toBe('text');
+    expect(next.caseSensitive).toBe(false);
+  });
+});
+
+describe('transforms', () => {
+  it('collapses whitespace deterministically', () => {
+    const result = applyTransform('text.collapse', '  Sample\n Value   ');
+
+    expect(result).toBe('Sample Value');
+  });
+
+  it('parses money strings into Money objects', () => {
+    const result = applyTransform('money.parse', 'USD 1,234.50');
+
+    expect(result).toEqual({
+      amount: 1234.5,
+      currencyCode: 'USD',
+      precision: 2,
+      raw: 'USD 1,234.50'
+    });
+  });
+
+  it('resolves relative URLs against a base URL', () => {
+    const result = applyTransform('url.resolve', '../assets/image.png', {
+      baseUrl: 'https://example.com/products/item/'
+    });
+
+    expect(result).toBe('https://example.com/products/assets/image.png');
+  });
+});
+

--- a/packages/core/src/recipe.ts
+++ b/packages/core/src/recipe.ts
@@ -1,0 +1,166 @@
+import { z } from 'zod';
+
+import { ProductSchema } from './schemas.js';
+import {
+  RecipeFieldIdSchema,
+  RecipeToleranceSchema,
+  type RecipeFieldId,
+  type RecipeTolerance
+} from './tolerances.js';
+import { TransformInvocationSchema, type TransformInvocation } from './transforms.js';
+
+const SelectorStrategySchema = z.enum(['css', 'xpath']);
+
+const PlaywrightDirectiveSchema = z
+  .object({
+    action: z.enum(['goto', 'click', 'fill', 'waitForSelector', 'evaluate']).optional(),
+    selector: z.string().min(1).optional(),
+    value: z.string().optional(),
+    description: z.string().optional()
+  })
+  .strict()
+  .optional();
+
+const SelectorStepSchema = z
+  .object({
+    strategy: SelectorStrategySchema.default('css'),
+    value: z.string().min(1, 'Selector value must not be empty'),
+    attribute: z.string().min(1).optional(),
+    ordinal: z.number().int().min(0).optional(),
+    all: z.boolean().default(false),
+    note: z.string().optional(),
+    playwright: PlaywrightDirectiveSchema
+  })
+  .strict();
+
+const ValidatorSchema = z.discriminatedUnion('type', [
+  z
+    .object({
+      type: z.literal('required')
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('regex'),
+      pattern: z.string().min(1),
+      flags: z.string().regex(/^[gimsuy]*$/).optional()
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('minLength'),
+      value: z.number().int().min(0)
+    })
+    .strict()
+]);
+
+export type RecipeValidator = z.infer<typeof ValidatorSchema>;
+
+const FieldMetricsSchema = z
+  .object({
+    sampleCount: z.number().int().min(0).default(0),
+    passCount: z.number().int().min(0).default(0),
+    failCount: z.number().int().min(0).default(0),
+    lastRunAt: z.coerce.date().optional()
+  })
+  .strict();
+
+export type FieldMetrics = z.infer<typeof FieldMetricsSchema>;
+
+const FieldRecipeSchema = z
+  .object({
+    fieldId: RecipeFieldIdSchema,
+    description: z.string().optional(),
+    selectorSteps: z.array(SelectorStepSchema).min(1),
+    transforms: z.array(TransformInvocationSchema).default([]),
+    tolerance: RecipeToleranceSchema,
+    validators: z.array(ValidatorSchema).default([]),
+    metrics: FieldMetricsSchema.default({ sampleCount: 0, passCount: 0, failCount: 0 }),
+    sample: z.unknown().optional()
+  })
+  .strict();
+
+export type FieldRecipe = z.infer<typeof FieldRecipeSchema>;
+
+const LifecycleStateSchema = z.enum(['draft', 'candidate', 'stable', 'retired']);
+
+export type LifecycleState = z.infer<typeof LifecycleStateSchema>;
+
+const LifecycleEventSchema = z
+  .object({
+    state: LifecycleStateSchema,
+    at: z.coerce.date(),
+    actor: z.string().optional(),
+    notes: z.string().optional()
+  })
+  .strict();
+
+export type LifecycleEvent = z.infer<typeof LifecycleEventSchema>;
+
+const RecipeLifecycleSchema = z
+  .object({
+    state: LifecycleStateSchema,
+    since: z.coerce.date(),
+    history: z.array(LifecycleEventSchema).default([])
+  })
+  .strict();
+
+export type RecipeLifecycle = z.infer<typeof RecipeLifecycleSchema>;
+
+const RecipeMetricsSchema = z
+  .object({
+    totalRuns: z.number().int().min(0).default(0),
+    successfulRuns: z.number().int().min(0).default(0),
+    averageDurationMs: z.number().nonnegative().optional(),
+    lastRunAt: z.coerce.date().optional()
+  })
+  .strict();
+
+export type RecipeMetrics = z.infer<typeof RecipeMetricsSchema>;
+
+const ProvenanceRecordSchema = z
+  .object({
+    fieldId: RecipeFieldIdSchema,
+    evidence: z.string().min(1),
+    confidence: z.number().min(0).max(1),
+    notes: z.string().optional()
+  })
+  .strict();
+
+export type ProvenanceRecord = z.infer<typeof ProvenanceRecordSchema>;
+
+const RecipeTargetSchema = z
+  .object({
+    documentType: z.literal('product'),
+    schema: ProductSchema,
+    fields: z.array(FieldRecipeSchema).min(1)
+  })
+  .strict();
+
+export type RecipeTarget = z.infer<typeof RecipeTargetSchema>;
+
+export const RecipeSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    name: z.string().min(1),
+    version: z.string().min(1),
+    description: z.string().optional(),
+    createdAt: z.coerce.date(),
+    updatedAt: z.coerce.date(),
+    createdBy: z.string().optional(),
+    updatedBy: z.string().optional(),
+    target: RecipeTargetSchema,
+    lifecycle: RecipeLifecycleSchema,
+    metrics: RecipeMetricsSchema.default({ totalRuns: 0, successfulRuns: 0 }),
+    provenance: z.array(ProvenanceRecordSchema).default([])
+  })
+  .strict();
+
+export type Recipe = z.infer<typeof RecipeSchema>;
+
+export function hasField(recipe: Recipe, field: RecipeFieldId): boolean {
+  return recipe.target.fields.some((entry) => entry.fieldId === field);
+}
+
+export type { RecipeFieldId, RecipeTolerance, TransformInvocation };
+

--- a/packages/core/src/tolerances.ts
+++ b/packages/core/src/tolerances.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+
+export const RecipeFieldIdSchema = z.enum([
+  'id',
+  'title',
+  'canonicalUrl',
+  'description',
+  'price',
+  'images',
+  'thumbnail',
+  'aggregateRating',
+  'breadcrumbs',
+  'brand',
+  'sku'
+]);
+
+export type RecipeFieldId = z.infer<typeof RecipeFieldIdSchema>;
+
+const TextToleranceSchema = z
+  .object({
+    kind: z.literal('text'),
+    trim: z.boolean().default(true),
+    caseSensitive: z.boolean().default(false),
+    maxDistanceRatio: z.number().min(0).max(1).default(0)
+  })
+  .strict();
+
+const MoneyToleranceSchema = z
+  .object({
+    kind: z.literal('money'),
+    maxAbsoluteMinorUnits: z.number().int().min(0).default(0),
+    maxRelativeDifference: z.number().min(0).max(1).default(0)
+  })
+  .strict();
+
+const UrlToleranceSchema = z
+  .object({
+    kind: z.literal('url'),
+    normalizeTrailingSlash: z.boolean().default(true),
+    ignoreQuery: z.boolean().default(false)
+  })
+  .strict();
+
+const ImageToleranceSchema = z
+  .object({
+    kind: z.literal('image'),
+    ignoreQuery: z.boolean().default(true)
+  })
+  .strict();
+
+const RatingToleranceSchema = z
+  .object({
+    kind: z.literal('rating'),
+    maxDelta: z.number().min(0).max(5).default(0.25)
+  })
+  .strict();
+
+const BreadcrumbToleranceSchema = z
+  .object({
+    kind: z.literal('breadcrumbs'),
+    allowReordering: z.boolean().default(false),
+    maxMissing: z.number().int().min(0).default(0)
+  })
+  .strict();
+
+export const RecipeToleranceSchema = z.discriminatedUnion('kind', [
+  TextToleranceSchema,
+  MoneyToleranceSchema,
+  UrlToleranceSchema,
+  ImageToleranceSchema,
+  RatingToleranceSchema,
+  BreadcrumbToleranceSchema
+]);
+
+export type RecipeTolerance = z.infer<typeof RecipeToleranceSchema>;
+
+type ToleranceByField = Record<RecipeFieldId, RecipeTolerance>;
+
+const DEFAULT_TOLERANCES: ToleranceByField = {
+  id: TextToleranceSchema.parse({ kind: 'text', caseSensitive: true }),
+  title: TextToleranceSchema.parse({ kind: 'text', maxDistanceRatio: 0 }),
+  canonicalUrl: UrlToleranceSchema.parse({ kind: 'url' }),
+  description: TextToleranceSchema.parse({ kind: 'text', maxDistanceRatio: 0.1 }),
+  price: MoneyToleranceSchema.parse({
+    kind: 'money',
+    maxAbsoluteMinorUnits: 1,
+    maxRelativeDifference: 0
+  }),
+  images: ImageToleranceSchema.parse({ kind: 'image' }),
+  thumbnail: ImageToleranceSchema.parse({ kind: 'image' }),
+  aggregateRating: RatingToleranceSchema.parse({ kind: 'rating', maxDelta: 0.1 }),
+  breadcrumbs: BreadcrumbToleranceSchema.parse({ kind: 'breadcrumbs' }),
+  brand: TextToleranceSchema.parse({ kind: 'text', maxDistanceRatio: 0.05 }),
+  sku: TextToleranceSchema.parse({ kind: 'text', caseSensitive: true })
+};
+
+export function getDefaultTolerance(fieldId: RecipeFieldId): RecipeTolerance {
+  const value = DEFAULT_TOLERANCES[fieldId];
+
+  if (!value) {
+    throw new Error(`No default tolerance registered for field "${fieldId}"`);
+  }
+
+  return structuredClone(value);
+}
+
+export function listDefaultTolerances(): readonly (readonly [RecipeFieldId, RecipeTolerance])[] {
+  const entries = Object.entries(DEFAULT_TOLERANCES).map(([field, tolerance]) => [
+    field as RecipeFieldId,
+    structuredClone(tolerance)
+  ] satisfies [RecipeFieldId, RecipeTolerance]);
+
+  return entries;
+}
+

--- a/packages/core/src/transforms.ts
+++ b/packages/core/src/transforms.ts
@@ -1,0 +1,199 @@
+import { z } from 'zod';
+
+import { CurrencyCodeSchema, MoneySchema } from './schemas.js';
+
+/**
+ * Built-in transforms must remain deterministic across environments and
+ * refrain from relying on host locale settings. All parsing assumes
+ * `en-US` number formatting (period decimal separator, optional comma
+ * thousands separators) and normalizes URLs using the WHATWG URL API.
+ */
+
+export const TransformNameSchema = z.enum(['text.collapse', 'money.parse', 'url.resolve']);
+
+export type TransformName = z.infer<typeof TransformNameSchema>;
+
+const TextCollapseOptionsSchema = z
+  .object({
+    collapseWhitespace: z.boolean().default(true),
+    trim: z.boolean().default(true),
+    preserveNewlines: z.boolean().default(false)
+  })
+  .strict();
+
+const MoneyParseOptionsSchema = z
+  .object({
+    currencyCode: CurrencyCodeSchema.default('USD'),
+    locale: z.literal('en-US').default('en-US'),
+    fallbackPrecision: z.number().int().min(0).max(4).default(2)
+  })
+  .strict();
+
+const UrlResolveOptionsSchema = z
+  .object({
+    baseUrl: z.string().url().optional(),
+    enforceHttps: z.boolean().default(false)
+  })
+  .strict();
+
+export type TextCollapseOptions = z.infer<typeof TextCollapseOptionsSchema>;
+export type MoneyParseOptions = z.infer<typeof MoneyParseOptionsSchema>;
+export type UrlResolveOptions = z.infer<typeof UrlResolveOptionsSchema>;
+
+interface TransformOptionsByName {
+  'text.collapse': TextCollapseOptions;
+  'money.parse': MoneyParseOptions;
+  'url.resolve': UrlResolveOptions;
+}
+
+const DEFAULT_TRANSFORM_OPTIONS: { [Name in TransformName]: TransformOptionsByName[Name] } = {
+  'text.collapse': TextCollapseOptionsSchema.parse({}),
+  'money.parse': MoneyParseOptionsSchema.parse({}),
+  'url.resolve': UrlResolveOptionsSchema.parse({})
+};
+
+export type TransformOptionsInput<Name extends TransformName> = Partial<TransformOptionsByName[Name]>;
+
+export interface TransformInvocation<Name extends TransformName = TransformName> {
+  name: Name;
+  options?: TransformOptionsInput<Name>;
+}
+
+const TextCollapseInvocationSchema = z
+  .object({
+    name: z.literal('text.collapse'),
+    options: TextCollapseOptionsSchema.partial().optional()
+  })
+  .strict();
+
+const MoneyParseInvocationSchema = z
+  .object({
+    name: z.literal('money.parse'),
+    options: MoneyParseOptionsSchema.partial().optional()
+  })
+  .strict();
+
+const UrlResolveInvocationSchema = z
+  .object({
+    name: z.literal('url.resolve'),
+    options: UrlResolveOptionsSchema.partial().optional()
+  })
+  .strict();
+
+export const TransformInvocationSchema = z.discriminatedUnion('name', [
+  TextCollapseInvocationSchema,
+  MoneyParseInvocationSchema,
+  UrlResolveInvocationSchema
+]);
+
+type NormalizedOptions<Name extends TransformName> = TransformOptionsByName[Name];
+
+export function resolveTransformOptions<Name extends TransformName>(
+  name: Name,
+  options?: TransformOptionsInput<Name>
+): NormalizedOptions<Name> {
+  const defaults = DEFAULT_TRANSFORM_OPTIONS[name];
+  if (!options) {
+    return { ...defaults };
+  }
+
+  return { ...defaults, ...options };
+}
+
+function applyTextCollapse(value: unknown, options: TextCollapseOptions): string {
+  if (typeof value !== 'string') {
+    throw new TypeError('text.collapse expects a string input');
+  }
+
+  const trimmed = options.trim ? value.trim() : value;
+
+  if (!options.collapseWhitespace) {
+    return trimmed;
+  }
+
+  if (options.preserveNewlines) {
+    return trimmed
+      .split(/\n+/)
+      .map((line) => line.replace(/\s+/g, ' ').trim())
+      .join('\n');
+  }
+
+  return trimmed.replace(/\s+/g, ' ');
+}
+
+function applyMoneyParse(value: unknown, options: MoneyParseOptions) {
+  if (typeof value !== 'string') {
+    throw new TypeError('money.parse expects a string input');
+  }
+
+  const raw = value.trim();
+  const sanitized = raw.replace(/[^0-9.,-]/g, '').replace(/,/g, '');
+  const amount = Number.parseFloat(sanitized);
+
+  if (Number.isNaN(amount)) {
+    throw new Error(`Unable to parse monetary value from "${value}"`);
+  }
+
+  const decimal = sanitized.split('.')[1] ?? '';
+  const precision = decimal.length > 0 ? Math.min(decimal.length, 4) : options.fallbackPrecision;
+
+  const result = MoneySchema.parse({
+    amount,
+    currencyCode: CurrencyCodeSchema.parse(options.currencyCode),
+    precision,
+    raw
+  });
+
+  return result;
+}
+
+function applyUrlResolve(value: unknown, options: UrlResolveOptions): string {
+  if (typeof value !== 'string') {
+    throw new TypeError('url.resolve expects a string input');
+  }
+
+  const raw = value.trim();
+  if (!raw) {
+    throw new Error('url.resolve cannot operate on an empty string');
+  }
+
+  let resolved: URL;
+
+  if (options.baseUrl) {
+    resolved = new URL(raw, options.baseUrl);
+  } else {
+    resolved = new URL(raw);
+  }
+
+  if (options.enforceHttps && resolved.protocol === 'http:') {
+    resolved = new URL(resolved.toString().replace(/^http:/, 'https:'));
+  }
+
+  return resolved.toString();
+}
+
+export function applyTransform<Name extends TransformName>(
+  name: Name,
+  value: unknown,
+  options?: TransformOptionsInput<Name>
+) {
+  const normalized = resolveTransformOptions(name, options);
+
+  switch (name) {
+    case 'text.collapse':
+      return applyTextCollapse(value, normalized as TextCollapseOptions);
+    case 'money.parse':
+      return applyMoneyParse(value, normalized as MoneyParseOptions);
+    case 'url.resolve':
+      return applyUrlResolve(value, normalized as UrlResolveOptions);
+    default: {
+      const exhaustiveCheck: never = name;
+      return exhaustiveCheck;
+    }
+  }
+}
+
+export function getDefaultTransformOptions<Name extends TransformName>(name: Name): NormalizedOptions<Name> {
+  return { ...DEFAULT_TRANSFORM_OPTIONS[name] };
+}
+

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    deps: {
+      inline: ['zod']
+    }
+  }
+});
+


### PR DESCRIPTION
## Summary
- add a unified recipe schema capturing selector steps, validators, lifecycle metadata, and metrics alongside helper exports
- define default tolerance policies per product field with lookup utilities
- expose deterministic transform implementations plus unit tests and vitest config for the core package

## Testing
- `pnpm --filter @mercator/core test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68cab2efea68832ca2e9c014d29eb051