### PR TITLE
Implement recipe workflow service and CLI

### DIFF
--- a/apps/service/package.json
+++ b/apps/service/package.json
@@ -13,13 +13,17 @@
   "dependencies": {
     "@ai-sdk/openai": "^2.0.30",
     "@mercator/agent-tools": "workspace:*",
+    "@mercator/core": "workspace:*",
     "@mercator/fixtures": "workspace:*",
+    "@mercator/recipe-store": "workspace:*",
     "cheerio": "^1.0.0",
     "@mastra/core": "^0.16.3",
     "@mastra/libsql": "^0.14.1",
     "@mastra/loggers": "^0.10.11",
     "@mastra/memory": "^0.15.1",
+    "commander": "^12.1.0",
     "dotenv": "^16.4.5",
+    "fastify": "^4.28.1",
     "zod": "^3.25.3"
   },
   "devDependencies": {

--- a/apps/service/src/cli/index.ts
+++ b/apps/service/src/cli/index.ts
@@ -1,0 +1,110 @@
+import { Command } from 'commander';
+
+import type { FixtureId } from '../recipes/fixtures.js';
+import { RecipeWorkflowService } from '../recipes/service.js';
+
+const SUPPORTED_FIXTURES: readonly FixtureId[] = ['product-simple'];
+
+const parseFixtureId = (value: string | undefined): FixtureId => {
+  if (!value) {
+    return 'product-simple';
+  }
+  if (!SUPPORTED_FIXTURES.includes(value as FixtureId)) {
+    throw new Error(`Unsupported fixture id: ${value}`);
+  }
+  return value as FixtureId;
+};
+
+export interface CreateCliOptions {
+  readonly service: RecipeWorkflowService;
+  readonly stdout?: NodeJS.WritableStream;
+  readonly stderr?: NodeJS.WritableStream;
+}
+
+export const createCli = (options: CreateCliOptions): Command => {
+  const program = new Command();
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const service = options.service;
+
+  const writeJson = (value: unknown) => {
+    const serialized = JSON.stringify(value, null, 2);
+    stdout.write(`${serialized}\n`);
+  };
+
+  const handle = <T extends unknown[]>(runner: (...args: T) => Promise<void>) => {
+    return async (...args: T) => {
+      try {
+        await runner(...args);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        stderr.write(`${message}\n`);
+        throw error;
+      }
+    };
+  };
+
+  program.name('mercator-service').description('Mercator recipe workflow CLI');
+
+  program
+    .command('recipes:generate')
+    .description('Run the orchestration loop to generate a draft recipe')
+    .option('--fixture <id>', 'Fixture identifier', 'product-simple')
+    .option('--html <path>', 'Path to HTML document for orchestration')
+    .option('--actor <actor>', 'Actor recorded for storage history')
+    .action(
+      handle(async (command: { fixture?: string; html?: string; actor?: string }) => {
+        const fixtureId = parseFixtureId(command.fixture);
+        const result = await service.generateRecipe({
+          fixtureId,
+          htmlPath: command.html,
+          actor: command.actor
+        });
+        writeJson({
+          recipeId: result.stored.id,
+          lifecycle: result.stored.recipe.lifecycle,
+          document: result.document
+        });
+      })
+    );
+
+  program
+    .command('recipes:promote <recipeId>')
+    .description('Promote a draft recipe to the stable lifecycle state')
+    .option('--actor <actor>', 'Actor recorded for promotion event')
+    .option('--notes <notes>', 'Optional notes added to lifecycle history')
+    .action(
+      handle(async (recipeId: string, command: { actor?: string; notes?: string }) => {
+        const promoted = await service.promoteRecipe(recipeId, {
+          actor: command.actor,
+          notes: command.notes
+        });
+        writeJson({
+          recipeId: promoted.id,
+          lifecycle: promoted.recipe.lifecycle
+        });
+      })
+    );
+
+  program
+    .command('parse')
+    .description('Execute the latest stable recipe against a document')
+    .option('--fixture <id>', 'Fixture identifier', 'product-simple')
+    .option('--html <path>', 'Path to HTML document to parse')
+    .action(
+      handle(async (command: { fixture?: string; html?: string }) => {
+        const fixtureId = parseFixtureId(command.fixture);
+        const result = await service.parseDocument({
+          fixtureId,
+          htmlPath: command.html
+        });
+        writeJson({
+          recipeId: result.recipe.id,
+          product: result.product,
+          document: result.document
+        });
+      })
+    );
+
+  return program;
+};

--- a/apps/service/src/http/server.ts
+++ b/apps/service/src/http/server.ts
@@ -1,0 +1,101 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { z } from 'zod';
+
+import type { FixtureId } from '../recipes/fixtures.js';
+import { RecipeWorkflowService } from '../recipes/service.js';
+
+const FixtureIdSchema = z.enum(['product-simple']);
+
+export interface CreateServerOptions {
+  readonly service: RecipeWorkflowService;
+}
+
+export const createServer = (options: CreateServerOptions): FastifyInstance => {
+  const app = Fastify({ logger: false });
+  const service = options.service;
+
+  const parseFixtureId = (value: string | undefined): FixtureId => {
+    if (!value) {
+      return 'product-simple';
+    }
+    const parsed = FixtureIdSchema.parse(value);
+    return parsed;
+  };
+
+  app.post('/recipes/generate', async (request, reply) => {
+    const schema = z
+      .object({
+        fixtureId: z.string().optional(),
+        htmlPath: z.string().optional(),
+        actor: z.string().optional()
+      })
+      .strict();
+
+    const body = schema.parse(request.body ?? {});
+    const fixtureId = parseFixtureId(body.fixtureId);
+    const result = await service.generateRecipe({
+      fixtureId,
+      htmlPath: body.htmlPath,
+      actor: body.actor
+    });
+
+    return reply.send({
+      recipeId: result.stored.id,
+      lifecycle: result.stored.recipe.lifecycle,
+      orchestration: result.orchestration,
+      document: result.document
+    });
+  });
+
+  app.post('/recipes/promote', async (request, reply) => {
+    const schema = z
+      .object({
+        recipeId: z.string().min(1),
+        actor: z.string().optional(),
+        notes: z.string().optional()
+      })
+      .strict();
+
+    const body = schema.parse(request.body ?? {});
+    const promoted = await service.promoteRecipe(body.recipeId, {
+      actor: body.actor,
+      notes: body.notes
+    });
+
+    return reply.send({
+      recipeId: promoted.id,
+      lifecycle: promoted.recipe.lifecycle
+    });
+  });
+
+  app.post('/parse', async (request, reply) => {
+    const schema = z
+      .object({
+        fixtureId: z.string().optional(),
+        htmlPath: z.string().optional()
+      })
+      .strict();
+
+    const body = schema.parse(request.body ?? {});
+    const fixtureId = parseFixtureId(body.fixtureId);
+    const result = await service.parseDocument({
+      fixtureId,
+      htmlPath: body.htmlPath
+    });
+
+    return reply.send({
+      recipeId: result.recipe.id,
+      product: result.product,
+      fieldValues: Object.fromEntries(result.fieldValues),
+      document: result.document
+    });
+  });
+
+  app.setErrorHandler((error, _request, reply) => {
+    const statusCode = error instanceof z.ZodError ? 400 : 500;
+    const message = error instanceof z.ZodError ? error.issues.map((issue) => issue.message).join('; ') : error.message;
+    reply.status(statusCode).send({ error: message });
+  });
+
+  return app;
+};

--- a/apps/service/src/recipes/execute.ts
+++ b/apps/service/src/recipes/execute.ts
@@ -1,0 +1,229 @@
+import { load, type CheerioAPI } from 'cheerio';
+
+import { ProductSchema, applyTransform, type Product, type Money } from '@mercator/core';
+import type { FieldRecipe, Recipe } from '@mercator/core';
+
+const FIELD_TO_PRODUCT_KEY: Record<FieldRecipe['fieldId'], keyof Product | null> = {
+  id: 'id',
+  title: 'title',
+  canonicalUrl: 'canonicalUrl',
+  description: 'description',
+  price: 'price',
+  images: 'images',
+  thumbnail: 'thumbnail',
+  aggregateRating: 'aggregateRating',
+  breadcrumbs: 'breadcrumbs',
+  brand: 'brand',
+  sku: 'sku'
+};
+
+interface RatingLike {
+  ratingValue: number;
+  reviewCount?: number;
+  bestRating?: number;
+  url?: string;
+}
+
+interface BreadcrumbLike {
+  label: string;
+  url?: string;
+  position?: number;
+}
+
+const sanitizeSku = (value: unknown): unknown => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  return value.replace(/^sku:\s*/i, '').trim();
+};
+
+const extractBreadcrumbs = ($: CheerioAPI): BreadcrumbLike[] => {
+  const items: BreadcrumbLike[] = [];
+  $('nav.breadcrumbs ol li').each((index, element) => {
+    const node = $(element);
+    const link = node.find('a').first();
+    const label = node.text().replace(/\s+/g, ' ').trim();
+    const url = link.attr('href') ?? undefined;
+    items.push({ label, url, position: index + 1 });
+  });
+  return items;
+};
+
+const extractAggregateRating = (
+  $: CheerioAPI,
+  canonicalUrl?: string
+): RatingLike | undefined => {
+  const container = $('[data-test="aggregate-rating"]');
+  if (!container.length) {
+    return undefined;
+  }
+
+  const ratingValueText = container.find('.rating__value').text();
+  const ratingValue = Number.parseFloat(ratingValueText);
+  if (!Number.isFinite(ratingValue)) {
+    return undefined;
+  }
+
+  const reviewCountText = container.find('.rating__count').text();
+  const reviewCount = Number.parseInt(reviewCountText.replace(/[^0-9]/g, ''), 10);
+  const bestRatingText = container.find('.rating__best').text();
+  const bestRating = Number.parseFloat(bestRatingText.replace(/[^0-9.]/g, ''));
+
+  const aggregate: RatingLike = { ratingValue };
+
+  if (Number.isFinite(reviewCount)) {
+    aggregate.reviewCount = reviewCount;
+  }
+
+  if (Number.isFinite(bestRating)) {
+    aggregate.bestRating = bestRating;
+  }
+
+  if (canonicalUrl) {
+    aggregate.url = `${canonicalUrl}#reviews`;
+  }
+
+  return aggregate;
+};
+
+const applyTransforms = (field: FieldRecipe, value: unknown): unknown => {
+  return field.transforms.reduce<unknown>((current, transform) => {
+    if (Array.isArray(current)) {
+      return current.map((entry) => applyTransform(transform.name, entry, transform.options));
+    }
+    return applyTransform(transform.name, current, transform.options);
+  }, value);
+};
+
+const extractFieldValue = (
+  $: CheerioAPI,
+  field: FieldRecipe,
+  context: Map<FieldRecipe['fieldId'], unknown>
+): unknown => {
+  if (field.fieldId === 'aggregateRating') {
+    const canonical = typeof context.get('canonicalUrl') === 'string' ? (context.get('canonicalUrl') as string) : undefined;
+    return extractAggregateRating($, canonical);
+  }
+
+  if (field.fieldId === 'breadcrumbs') {
+    return extractBreadcrumbs($);
+  }
+
+  const [firstStep] = field.selectorSteps;
+  if (!firstStep) {
+    return undefined;
+  }
+
+  const selection = $(firstStep.value);
+  const ordinal = typeof firstStep.ordinal === 'number' ? Number(firstStep.ordinal) : undefined;
+  const baseSelection = typeof ordinal === 'number' ? selection.eq(ordinal) : selection;
+
+  const extractSingle = () => {
+    const attributeName = firstStep.attribute;
+    if (typeof attributeName === 'string') {
+      const attributeValue = baseSelection.first().attr(attributeName);
+      return typeof attributeValue === 'string' ? attributeValue : '';
+    }
+    return baseSelection.first().text();
+  };
+
+  const extractAll = () => {
+    const nodes = baseSelection.toArray();
+    return nodes.map((element) => {
+      const node = $(element);
+      const attributeName = firstStep.attribute;
+      if (typeof attributeName === 'string') {
+        const attributeValue = node.attr(attributeName);
+        return typeof attributeValue === 'string' ? attributeValue : '';
+      }
+      return node.text();
+    });
+  };
+
+  let value: unknown;
+  if (firstStep.all) {
+    value = extractAll();
+  } else {
+    value = extractSingle();
+  }
+
+  const transformed = applyTransforms(field, value);
+
+  if (field.fieldId === 'sku') {
+    return sanitizeSku(transformed);
+  }
+
+  return transformed;
+};
+
+const assignProductValue = (
+  productInput: Record<string, unknown>,
+  fieldId: FieldRecipe['fieldId'],
+  value: unknown
+) => {
+  const key = FIELD_TO_PRODUCT_KEY[fieldId];
+  if (!key || value === undefined) {
+    return;
+  }
+
+  if (fieldId === 'images' && Array.isArray(value)) {
+    productInput[key] = value.filter((entry): entry is string => typeof entry === 'string');
+    return;
+  }
+
+  if (fieldId === 'price' && value && typeof value === 'object') {
+    productInput[key] = value as Money;
+    return;
+  }
+
+  productInput[key] = value;
+};
+
+export interface RecipeExecutionResult {
+  readonly product: Product;
+  readonly fieldValues: Map<FieldRecipe['fieldId'], unknown>;
+}
+
+export const executeRecipe = (html: string, recipe: Recipe): RecipeExecutionResult => {
+  const $ = load(html);
+  const values = new Map<FieldRecipe['fieldId'], unknown>();
+
+  for (const field of recipe.target.fields) {
+    const value = extractFieldValue($, field, values);
+    values.set(field.fieldId, value);
+  }
+
+  const productInput: Record<string, unknown> = {};
+
+  const required: FieldRecipe['fieldId'][] = ['title', 'canonicalUrl', 'price', 'images'];
+  for (const fieldId of required) {
+    const value = values.get(fieldId);
+    if (value === undefined || value === null || (Array.isArray(value) && value.length === 0)) {
+      throw new Error(`Missing required field "${fieldId}" when executing recipe.`);
+    }
+    assignProductValue(productInput, fieldId, value);
+  }
+
+  const optional: FieldRecipe['fieldId'][] = [
+    'description',
+    'thumbnail',
+    'aggregateRating',
+    'breadcrumbs',
+    'brand',
+    'sku'
+  ];
+
+  for (const fieldId of optional) {
+    const value = values.get(fieldId);
+    if (value !== undefined) {
+      assignProductValue(productInput, fieldId, value);
+    }
+  }
+
+  const product = ProductSchema.parse(productInput);
+
+  return {
+    product,
+    fieldValues: values
+  };
+};

--- a/apps/service/src/recipes/fixtures.ts
+++ b/apps/service/src/recipes/fixtures.ts
@@ -1,0 +1,68 @@
+import { readFile } from 'node:fs/promises';
+
+import type { FixtureToolset } from '@mercator/agent-tools';
+import { loadProductSimpleFixture } from '@mercator/fixtures';
+
+import {
+  createProductSimpleDocument,
+  createProductSimpleRuleSet,
+  createProductSimpleToolset
+} from '../orchestrator/__fixtures__/product-simple.js';
+import type { DocumentRuleSet } from '../orchestrator/rule-repository.js';
+import type { DocumentSnapshot } from '../orchestrator/index.js';
+
+export type FixtureId = 'product-simple';
+
+export interface FixtureDefinition {
+  readonly id: FixtureId;
+  readonly domain: string;
+  readonly path: string;
+  readonly defaultHtml: string;
+  readonly htmlPath: string;
+  createToolset(): FixtureToolset;
+  createRuleSet(): DocumentRuleSet;
+}
+
+const loadProductSimpleDefinition = (): FixtureDefinition => {
+  const fixture = loadProductSimpleFixture();
+  const document = createProductSimpleDocument();
+  return {
+    id: 'product-simple',
+    domain: document.domain,
+    path: document.path,
+    defaultHtml: fixture.html,
+    htmlPath: fixture.paths.html,
+    createToolset: () => createProductSimpleToolset(),
+    createRuleSet: () => createProductSimpleRuleSet()
+  } satisfies FixtureDefinition;
+};
+
+const FIXTURE_CACHE: Record<FixtureId, FixtureDefinition> = {
+  'product-simple': loadProductSimpleDefinition()
+};
+
+export const getFixtureDefinition = (id: FixtureId = 'product-simple'): FixtureDefinition => {
+  const definition = FIXTURE_CACHE[id];
+  if (!definition) {
+    throw new Error(`Unsupported fixture id: ${id}`);
+  }
+  return {
+    ...definition,
+    createToolset: () => definition.createToolset(),
+    createRuleSet: () => definition.createRuleSet()
+  };
+};
+
+export const readFixtureDocument = async (
+  fixtureId: FixtureId,
+  htmlPath?: string
+): Promise<DocumentSnapshot> => {
+  const definition = getFixtureDefinition(fixtureId);
+  const path = htmlPath ?? definition.htmlPath;
+  const html = htmlPath ? await readFile(path, 'utf-8') : definition.defaultHtml;
+  return {
+    domain: definition.domain,
+    path: definition.path,
+    html
+  };
+};

--- a/apps/service/src/recipes/index.ts
+++ b/apps/service/src/recipes/index.ts
@@ -1,0 +1,12 @@
+export { executeRecipe } from './execute.js';
+export { getFixtureDefinition, readFixtureDocument } from './fixtures.js';
+export type { FixtureId, FixtureDefinition } from './fixtures.js';
+export { RecipeWorkflowService } from './service.js';
+export type {
+  GenerateRecipeOptions,
+  GenerateRecipeResult,
+  PromoteRecipeOptions,
+  ParseDocumentOptions,
+  ParseDocumentResult
+} from './service.js';
+export { createWorkflowService } from './setup.js';

--- a/apps/service/src/recipes/service.integration.test.ts
+++ b/apps/service/src/recipes/service.integration.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Writable } from 'node:stream';
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+
+import { loadProductSimpleFixture } from '@mercator/fixtures';
+import { LocalFileSystemRecipeStore } from '@mercator/recipe-store';
+
+import { createCli } from '../cli/index.js';
+import { createServer } from '../http/server.js';
+import { createProductSimpleRuleSet } from '../orchestrator/__fixtures__/product-simple.js';
+import { createInMemoryRuleRepository } from '../orchestrator/rule-repository.js';
+import { RecipeWorkflowService } from './service.js';
+
+describe('RecipeWorkflowService integration', () => {
+  let directory: string;
+  let service: RecipeWorkflowService;
+  let server: ReturnType<typeof createServer>;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), 'mercator-recipes-'));
+    const store = new LocalFileSystemRecipeStore({ directory });
+    const ruleRepository = createInMemoryRuleRepository([createProductSimpleRuleSet()]);
+    service = new RecipeWorkflowService({ store, ruleRepository });
+    server = createServer({ service });
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it('generates, promotes, and parses a recipe using fixture HTML path', async () => {
+    const fixture = loadProductSimpleFixture();
+    const htmlPath = fixture.paths.html;
+
+    const GenerateResponseSchema = z.object({
+      recipeId: z.string(),
+      document: z.object({ domain: z.string(), path: z.string() })
+    });
+    const generateResponse = await server.inject({
+      method: 'POST',
+      url: '/recipes/generate',
+      payload: { fixtureId: 'product-simple', htmlPath }
+    });
+    expect(generateResponse.statusCode).toBe(200);
+    const generateBody = GenerateResponseSchema.parse(generateResponse.json());
+    expect(generateBody.document.domain).toBe('demo.mercator.sh');
+
+    const stdoutChunks: string[] = [];
+    const cli = createCli({
+      service,
+      stdout: new Writable({
+        write(chunk, _encoding, callback) {
+          stdoutChunks.push(String(chunk));
+          callback();
+        }
+      }),
+      stderr: new Writable({
+        write(chunk, _encoding, callback) {
+          callback(new Error(`CLI error: ${String(chunk)}`));
+        }
+      })
+    });
+    cli.exitOverride();
+
+    const PromoteOutputSchema = z.object({ recipeId: z.string() }).passthrough();
+    await cli.parseAsync(['recipes:promote', generateBody.recipeId], { from: 'user' });
+    const cliOutput = stdoutChunks.join('');
+    const promotedOutput = PromoteOutputSchema.parse(JSON.parse(cliOutput));
+    expect(promotedOutput.recipeId).toBe(generateBody.recipeId);
+
+    const ParseResponseSchema = z
+      .object({
+        product: z.object({
+          title: z.string(),
+          price: z.object({ amount: z.number() })
+        })
+      })
+      .passthrough();
+    const parseResponse = await server.inject({
+      method: 'POST',
+      url: '/parse',
+      payload: { fixtureId: 'product-simple', htmlPath }
+    });
+    expect(parseResponse.statusCode).toBe(200);
+    const parseBody = ParseResponseSchema.parse(parseResponse.json());
+
+    expect(parseBody.product.title).toContain('Precision');
+    expect(parseBody.product.price.amount).toBeGreaterThan(0);
+  });
+});

--- a/apps/service/src/recipes/service.ts
+++ b/apps/service/src/recipes/service.ts
@@ -1,0 +1,117 @@
+import { RecipeSchema } from '@mercator/core';
+import type { OrchestrationResult } from '@mercator/core/agents';
+import { executeRecipe } from './execute.js';
+import { getFixtureDefinition, readFixtureDocument, type FixtureId } from './fixtures.js';
+import { runAgentOrchestrationSlice, type DocumentSnapshot } from '../orchestrator/index.js';
+import { createInMemoryRuleRepository, type DocumentRuleRepository } from '../orchestrator/rule-repository.js';
+import type { RecipeStore, StoredRecipe } from '@mercator/recipe-store';
+
+export interface RecipeWorkflowServiceOptions {
+  readonly store: RecipeStore;
+  readonly ruleRepository?: DocumentRuleRepository;
+  readonly now?: () => Date;
+}
+
+export interface GenerateRecipeOptions {
+  readonly fixtureId?: FixtureId;
+  readonly htmlPath?: string;
+  readonly actor?: string;
+}
+
+export interface GenerateRecipeResult {
+  readonly stored: StoredRecipe;
+  readonly orchestration: OrchestrationResult;
+  readonly document: DocumentSnapshot;
+}
+
+export interface PromoteRecipeOptions {
+  readonly actor?: string;
+  readonly notes?: string;
+}
+
+export interface ParseDocumentOptions {
+  readonly fixtureId?: FixtureId;
+  readonly htmlPath?: string;
+}
+
+export interface ParseDocumentResult {
+  readonly recipe: StoredRecipe;
+  readonly product: ReturnType<typeof executeRecipe>['product'];
+  readonly fieldValues: ReturnType<typeof executeRecipe>['fieldValues'];
+  readonly document: DocumentSnapshot;
+}
+
+const createDefaultRuleRepository = (): DocumentRuleRepository => {
+  const fixture = getFixtureDefinition('product-simple');
+  return createInMemoryRuleRepository([fixture.createRuleSet()]);
+};
+
+export class RecipeWorkflowService {
+  private readonly store: RecipeStore;
+  private readonly ruleRepository: DocumentRuleRepository;
+  private readonly now: () => Date;
+
+  constructor(options: RecipeWorkflowServiceOptions) {
+    this.store = options.store;
+    this.ruleRepository = options.ruleRepository ?? createDefaultRuleRepository();
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async generateRecipe(options: GenerateRecipeOptions = {}): Promise<GenerateRecipeResult> {
+    const fixtureId = options.fixtureId ?? 'product-simple';
+    const fixture = getFixtureDefinition(fixtureId);
+    const document = await readFixtureDocument(fixtureId, options.htmlPath);
+    const toolset = fixture.createToolset();
+
+    const orchestration: OrchestrationResult = await runAgentOrchestrationSlice({
+      document,
+      toolset,
+      ruleRepository: this.ruleRepository,
+      now: this.now
+    });
+
+    const parseResult = RecipeSchema.safeParse(orchestration.synthesis.recipe);
+    if (!parseResult.success) {
+      throw new Error('Generated recipe failed schema validation.');
+    }
+
+    const { data: recipe } = parseResult;
+
+    // The recipe has been validated via Zod safeParse, but zod's typings cause
+    // eslint to treat the value as `any` here.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const stored = await this.store.createDraft(recipe, {
+      actor: options.actor,
+      notes: 'Recipe generated via orchestration.',
+      when: this.now()
+    });
+
+    return { stored, orchestration, document };
+  }
+
+  async promoteRecipe(id: string, options: PromoteRecipeOptions = {}): Promise<StoredRecipe> {
+    return this.store.promote(id, {
+      actor: options.actor,
+      notes: options.notes ?? 'Promoted via workflow service.',
+      when: this.now()
+    });
+  }
+
+  async parseDocument(options: ParseDocumentOptions = {}): Promise<ParseDocumentResult> {
+    const stable = await this.store.getLatestStable();
+    if (!stable) {
+      throw new Error('No stable recipe available for execution.');
+    }
+
+    const fixtureId = options.fixtureId ?? 'product-simple';
+    const document = await readFixtureDocument(fixtureId, options.htmlPath);
+    const execution = executeRecipe(document.html, stable.recipe);
+
+    return {
+      recipe: stable,
+      product: execution.product,
+      fieldValues: execution.fieldValues,
+      document
+    };
+  }
+}

--- a/apps/service/src/recipes/setup.ts
+++ b/apps/service/src/recipes/setup.ts
@@ -1,0 +1,18 @@
+import { resolve } from 'node:path';
+
+import { LocalFileSystemRecipeStore } from '@mercator/recipe-store';
+
+import { RecipeWorkflowService } from './service.js';
+
+export interface CreateWorkflowServiceOptions {
+  readonly directory?: string;
+  readonly now?: () => Date;
+}
+
+export const createWorkflowService = (
+  options: CreateWorkflowServiceOptions = {}
+): RecipeWorkflowService => {
+  const directory = options.directory ?? process.env.MERCATOR_RECIPES_DIR ?? resolve(process.cwd(), '.recipes');
+  const store = new LocalFileSystemRecipeStore({ directory, now: options.now });
+  return new RecipeWorkflowService({ store, now: options.now });
+};

--- a/packages/recipe-store/package.json
+++ b/packages/recipe-store/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@mercator/recipe-store",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "lint": "eslint src --ext .ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@mercator/core": "workspace:*"
+  }
+}

--- a/packages/recipe-store/src/index.ts
+++ b/packages/recipe-store/src/index.ts
@@ -1,0 +1,2 @@
+export type { StoredRecipe, RecipeStore, PromotionOptions, CreateDraftOptions } from './types.js';
+export { LocalFileSystemRecipeStore, type LocalFileSystemRecipeStoreOptions } from './local-file-system.js';

--- a/packages/recipe-store/src/local-file-system.test.ts
+++ b/packages/recipe-store/src/local-file-system.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+
+import {
+  RecipeSchema,
+  getDefaultTolerance,
+  type Recipe,
+  type RecipeFieldId
+} from '@mercator/core';
+
+import { LocalFileSystemRecipeStore } from './local-file-system.js';
+
+const REQUIRED_FIELDS: RecipeFieldId[] = ['title', 'canonicalUrl', 'price', 'images'];
+
+const createBaseRecipe = (timestamp: Date): Recipe => {
+  const iso = timestamp.toISOString();
+  return RecipeSchema.parse({
+    name: 'demo-product',
+    version: '1.0.0',
+    description: 'Demonstration recipe for tests.',
+    createdAt: iso,
+    updatedAt: iso,
+    createdBy: 'tester@mercator',
+    updatedBy: 'tester@mercator',
+    target: {
+      documentType: 'product',
+      schema: {
+        title: 'Test Product',
+        canonicalUrl: 'https://demo.mercator.sh/products/test',
+        price: { amount: 129, currencyCode: 'USD', precision: 2, raw: '$129.00' },
+        images: ['https://demo.mercator.sh/assets/test.jpg']
+      },
+      fields: REQUIRED_FIELDS.map((fieldId) => ({
+        fieldId,
+        selectorSteps: [
+          {
+            strategy: 'css',
+            value: `#${fieldId}`
+          }
+        ],
+        tolerance: getDefaultTolerance(fieldId),
+        transforms: [],
+        validators: [],
+        metrics: { sampleCount: 0, passCount: 0, failCount: 0 }
+      }))
+    },
+    lifecycle: {
+      state: 'draft',
+      since: iso,
+      history: [
+        {
+          state: 'draft',
+          at: iso,
+          actor: 'tester@mercator',
+          notes: 'Initial draft generated for testing.'
+        }
+      ]
+    },
+    provenance: []
+  });
+};
+
+describe('LocalFileSystemRecipeStore', () => {
+  let directory: string;
+  const timestamps: Date[] = [
+    new Date('2024-01-01T00:00:00Z'),
+    new Date('2024-01-01T00:05:00Z'),
+    new Date('2024-01-01T00:10:00Z')
+  ];
+  let clock = 0;
+
+  const nextTime = () => timestamps[Math.min(clock++, timestamps.length - 1)];
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), 'recipe-store-'));
+    clock = 0;
+  });
+
+  afterEach(async () => {
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it('persists draft recipes to disk with generated identifiers', async () => {
+    const store = new LocalFileSystemRecipeStore({ directory, now: nextTime });
+    const recipe = createBaseRecipe(timestamps[0]);
+
+    const stored = await store.createDraft(recipe);
+
+    expect(stored.id).toMatch(/[0-9a-f-]{36}/i);
+    expect(stored.recipe.id).toBe(stored.id);
+    expect(stored.recipe.lifecycle.state).toBe('draft');
+    expect(stored.updatedAt.toISOString()).toBe(timestamps[0].toISOString());
+
+    const files = await readdir(directory);
+    expect(files).toContain(`${stored.id}.json`);
+  });
+
+  it('promotes draft recipes to stable and records lifecycle history', async () => {
+    const store = new LocalFileSystemRecipeStore({ directory, now: nextTime });
+    const recipe = createBaseRecipe(timestamps[0]);
+
+    const draft = await store.createDraft(recipe);
+    const promoted = await store.promote(draft.id, { actor: 'qa@mercator' });
+
+    expect(promoted.recipe.lifecycle.state).toBe('stable');
+    const lastHistory = promoted.recipe.lifecycle.history.at(-1);
+    expect(lastHistory?.state).toBe('stable');
+    expect(lastHistory?.actor).toBe('qa@mercator');
+    expect(promoted.promotedAt?.toISOString()).toBe(timestamps[1].toISOString());
+  });
+
+  it('lists recipes filtered by lifecycle state and returns latest stable entry', async () => {
+    const store = new LocalFileSystemRecipeStore({ directory, now: nextTime });
+    const recipe = createBaseRecipe(timestamps[0]);
+
+    const draft = await store.createDraft(recipe);
+    const entriesBeforePromotion = await store.list();
+    expect(entriesBeforePromotion).toHaveLength(1);
+    expect(entriesBeforePromotion[0]?.recipe.lifecycle.state).toBe('draft');
+
+    await store.promote(draft.id, { notes: 'Ready for execution.' });
+    const allEntries = await store.list();
+    expect(allEntries).toHaveLength(1);
+    expect(allEntries[0]?.recipe.lifecycle.state).toBe('stable');
+
+    const stableEntries = await store.list({ state: 'stable' });
+    expect(stableEntries).toHaveLength(1);
+
+    const latestStable = await store.getLatestStable();
+    expect(latestStable?.id).toBe(draft.id);
+  });
+
+  it('throws when promoting non-existent or already stable recipes', async () => {
+    const store = new LocalFileSystemRecipeStore({ directory, now: nextTime });
+    const recipe = createBaseRecipe(timestamps[0]);
+
+    await expect(store.promote('missing')).rejects.toThrow(/not found/i);
+
+    const draft = await store.createDraft(recipe);
+    await store.promote(draft.id);
+
+    await expect(store.promote(draft.id)).rejects.toThrow(/already stable/i);
+  });
+});

--- a/packages/recipe-store/src/local-file-system.ts
+++ b/packages/recipe-store/src/local-file-system.ts
@@ -1,0 +1,271 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { RecipeSchema, type LifecycleState, type Recipe } from '@mercator/core';
+
+import type {
+  CreateDraftOptions,
+  PromotionOptions,
+  RecipeStore,
+  StoredRecipe
+} from './types.js';
+
+interface FileRecord {
+  readonly id: string;
+  readonly recipe: Recipe;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly promotedAt?: string;
+}
+
+const isLifecycleState = (value: unknown): value is LifecycleState => {
+  return value === 'draft' || value === 'candidate' || value === 'stable' || value === 'retired';
+};
+
+const normalizeHistory = (
+  history: Recipe['lifecycle']['history']
+): Recipe['lifecycle']['history'] => history.map((event) => ({
+  ...event,
+  at: new Date(event.at)
+}));
+
+export interface LocalFileSystemRecipeStoreOptions {
+  readonly directory: string;
+  readonly now?: () => Date;
+}
+
+export class LocalFileSystemRecipeStore implements RecipeStore {
+  private readonly directory: string;
+  private readonly now: () => Date;
+  private readonly ready: Promise<void>;
+
+  constructor(options: LocalFileSystemRecipeStoreOptions) {
+    this.directory = options.directory;
+    this.now = options.now ?? (() => new Date());
+    this.ready = mkdir(this.directory, { recursive: true });
+  }
+
+  async createDraft(recipe: Recipe, options: CreateDraftOptions = {}): Promise<StoredRecipe> {
+    await this.ready;
+
+    const candidate = RecipeSchema.parse(recipe);
+    if (candidate.lifecycle.state !== 'draft') {
+      throw new Error('Only draft recipes may be stored.');
+    }
+
+    const id = candidate.id ?? randomUUID();
+    const now = options.when ?? this.now();
+
+    const history = normalizeHistory(candidate.lifecycle.history);
+    const lastEvent = history.at(-1);
+    const draftHistory =
+      lastEvent && lastEvent.state === 'draft'
+        ? history
+        : [
+            ...history,
+            {
+              state: 'draft' as const,
+              at: now,
+              actor: options.actor,
+              notes: options.notes ?? 'Recipe stored as draft'
+            }
+          ];
+
+    const normalized = RecipeSchema.parse({
+      ...candidate,
+      id,
+      updatedAt: now,
+      lifecycle: {
+        state: 'draft',
+        since: candidate.lifecycle.state === 'draft' ? candidate.lifecycle.since : now,
+        history: draftHistory
+      }
+    });
+
+    const record: FileRecord = {
+      id,
+      recipe: normalized,
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString()
+    };
+
+    await this.writeRecord(record);
+
+    return this.hydrate(record);
+  }
+
+  async list(options: { state?: LifecycleState } = {}): Promise<readonly StoredRecipe[]> {
+    await this.ready;
+    const entries = await readdir(this.directory, { withFileTypes: true });
+    const recipes: StoredRecipe[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.json')) {
+        continue;
+      }
+
+      const record = await this.readRecord(entry.name);
+      if (!record) {
+        continue;
+      }
+
+      if (options.state && record.recipe.lifecycle.state !== options.state) {
+        continue;
+      }
+
+      recipes.push(record);
+    }
+
+    return recipes.sort((a, b) => a.updatedAt.getTime() - b.updatedAt.getTime());
+  }
+
+  async getById(id: string): Promise<StoredRecipe | undefined> {
+    await this.ready;
+    const record = await this.readRecord(`${id}.json`);
+    return record;
+  }
+
+  async promote(id: string, options: PromotionOptions = {}): Promise<StoredRecipe> {
+    await this.ready;
+    const record = await this.readRecord(`${id}.json`);
+
+    if (!record) {
+      throw new Error(`Recipe ${id} not found.`);
+    }
+
+    if (record.recipe.lifecycle.state === 'stable') {
+      throw new Error('Recipe is already stable.');
+    }
+
+    if (record.recipe.lifecycle.state !== 'draft') {
+      throw new Error('Only draft recipes can be promoted.');
+    }
+
+    const now = options.when ?? this.now();
+    const history = normalizeHistory(record.recipe.lifecycle.history);
+    const promotedHistory = [
+      ...history,
+      {
+        state: 'stable' as const,
+        at: now,
+        actor: options.actor,
+        notes: options.notes ?? 'Promoted to stable'
+      }
+    ];
+
+    const updatedRecipe = RecipeSchema.parse({
+      ...record.recipe,
+      updatedAt: now,
+      updatedBy: options.actor ?? record.recipe.updatedBy,
+      lifecycle: {
+        state: 'stable',
+        since: now,
+        history: promotedHistory
+      }
+    });
+
+    const next: FileRecord = {
+      ...record,
+      recipe: updatedRecipe,
+      updatedAt: now.toISOString(),
+      promotedAt: now.toISOString()
+    };
+
+    await this.writeRecord(next);
+    return this.hydrate(next);
+  }
+
+  async getLatestStable(): Promise<StoredRecipe | undefined> {
+    const entries = await this.list({ state: 'stable' });
+    return entries.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+  }
+
+  private async readRecord(fileName: string): Promise<StoredRecipe | undefined> {
+    const filePath = join(this.directory, fileName);
+    let raw: string;
+    try {
+      raw = await readFile(filePath, 'utf-8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return undefined;
+      }
+      throw error;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<FileRecord> & { recipe?: unknown };
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error(`Invalid recipe record in ${fileName}`);
+    }
+
+    if (!parsed.id || typeof parsed.id !== 'string') {
+      throw new Error(`Recipe record ${fileName} is missing an id.`);
+    }
+
+    if (!parsed.createdAt || !parsed.updatedAt) {
+      throw new Error(`Recipe record ${fileName} is missing timestamps.`);
+    }
+
+    if (!parsed.recipe) {
+      throw new Error(`Recipe record ${fileName} is missing recipe data.`);
+    }
+
+    const recipe = RecipeSchema.parse(parsed.recipe);
+    return {
+      id: parsed.id,
+      recipe,
+      createdAt: new Date(parsed.createdAt),
+      updatedAt: new Date(parsed.updatedAt),
+      promotedAt: parsed.promotedAt ? new Date(parsed.promotedAt) : undefined
+    } satisfies StoredRecipe;
+  }
+
+  private async writeRecord(record: FileRecord): Promise<void> {
+    const filePath = join(this.directory, `${record.id}.json`);
+    const serialized = JSON.stringify(
+      {
+        ...record,
+        recipe: {
+          ...record.recipe,
+          createdAt: record.recipe.createdAt.toISOString(),
+          updatedAt: record.recipe.updatedAt.toISOString(),
+          lifecycle: {
+            ...record.recipe.lifecycle,
+            since: record.recipe.lifecycle.since.toISOString(),
+            history: record.recipe.lifecycle.history.map((event) => ({
+              ...event,
+              at: event.at.toISOString()
+            }))
+          }
+        }
+      },
+      null,
+      2
+    );
+
+    await writeFile(filePath, `${serialized}\n`, 'utf-8');
+  }
+
+  private hydrate(record: FileRecord): StoredRecipe {
+    const recipe = RecipeSchema.parse(record.recipe);
+    const lifecycle = {
+      ...recipe.lifecycle,
+      history: normalizeHistory(recipe.lifecycle.history)
+    };
+
+    return {
+      id: record.id,
+      recipe: {
+        ...recipe,
+        lifecycle
+      },
+      createdAt: new Date(record.createdAt),
+      updatedAt: new Date(record.updatedAt),
+      promotedAt: record.promotedAt ? new Date(record.promotedAt) : undefined
+    };
+  }
+}
+
+export function isValidLifecycleState(state: unknown): state is LifecycleState {
+  return isLifecycleState(state);
+}

--- a/packages/recipe-store/src/types.ts
+++ b/packages/recipe-store/src/types.ts
@@ -1,0 +1,29 @@
+import type { LifecycleState, Recipe } from '@mercator/core';
+
+export interface StoredRecipe {
+  readonly id: string;
+  readonly recipe: Recipe;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly promotedAt?: Date;
+}
+
+export interface CreateDraftOptions {
+  readonly actor?: string;
+  readonly notes?: string;
+  readonly when?: Date;
+}
+
+export interface PromotionOptions {
+  readonly actor?: string;
+  readonly notes?: string;
+  readonly when?: Date;
+}
+
+export interface RecipeStore {
+  createDraft(recipe: Recipe, options?: CreateDraftOptions): Promise<StoredRecipe>;
+  list(options?: { state?: LifecycleState }): Promise<readonly StoredRecipe[]>;
+  getById(id: string): Promise<StoredRecipe | undefined>;
+  promote(id: string, options?: PromotionOptions): Promise<StoredRecipe>;
+  getLatestStable(): Promise<StoredRecipe | undefined>;
+}

--- a/packages/recipe-store/tsconfig.json
+++ b/packages/recipe-store/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/recipe-store/vitest.config.ts
+++ b/packages/recipe-store/vitest.config.ts
@@ -1,0 +1,17 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  },
+  resolve: {
+    alias: {
+      '@mercator/core': resolve(__dirname, '../core/src/index.ts')
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,15 +50,27 @@ importers:
       '@mercator/agent-tools':
         specifier: workspace:*
         version: link:../../packages/agent-tools
+      '@mercator/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@mercator/fixtures':
         specifier: workspace:*
         version: link:../../packages/fixtures
+      '@mercator/recipe-store':
+        specifier: workspace:*
+        version: link:../../packages/recipe-store
       cheerio:
         specifier: ^1.0.0
         version: 1.1.2
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
+      fastify:
+        specifier: ^4.28.1
+        version: 4.29.1
       zod:
         specifier: ^3.25.3
         version: 3.25.76
@@ -102,6 +114,12 @@ importers:
         version: 3.25.76
 
   packages/fixtures:
+    dependencies:
+      '@mercator/core':
+        specifier: workspace:*
+        version: link:../core
+
+  packages/recipe-store:
     dependencies:
       '@mercator/core':
         specifier: workspace:*
@@ -649,6 +667,18 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fastify/ajv-compiler@3.6.0':
+    resolution: {integrity: sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==}
+
+  '@fastify/error@3.4.1':
+    resolution: {integrity: sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==}
+
+  '@fastify/fast-json-stringify-compiler@4.3.0':
+    resolution: {integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==}
+
+  '@fastify/merge-json-schemas@0.1.1':
+    resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
 
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
@@ -1742,6 +1772,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1785,8 +1818,27 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1815,6 +1867,9 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  avvio@8.4.0:
+    resolution: {integrity: sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==}
 
   axios@1.12.2:
     resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
@@ -2278,8 +2333,14 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-content-type-parse@1.1.0:
+    resolution: {integrity: sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==}
+
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
+
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2291,8 +2352,14 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@5.16.1:
+    resolution: {integrity: sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
@@ -2300,6 +2367,15 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@2.4.0:
+    resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastify@4.29.1:
+    resolution: {integrity: sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -2336,6 +2412,10 @@ packages:
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
+
+  find-my-way@8.2.2:
+    resolution: {integrity: sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==}
+    engines: {node: '>=14'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2682,12 +2762,18 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-ref-resolver@1.0.1:
+    resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
+
   json-schema-to-zod@2.6.1:
     resolution: {integrity: sha512-uiHmWH21h9FjKJkRBntfVGTLpYlCZ1n98D0izIlByqQLqpmkQpNTBtfbdP04Na6+43lgsvrShFh2uWLkQDKJuQ==}
     hasBin: true
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-walker@2.0.0:
     resolution: {integrity: sha512-nXN2cMky0Iw7Af28w061hmxaPDaML5/bQD9nwm1lOoIKEGjHcRGxqWe4MfrkYThYAPjSUhmsp4bJNoLAyVn9Xw==}
@@ -2722,6 +2808,9 @@ packages:
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
     os: [darwin, linux, win32]
+
+  light-my-request@5.14.0:
+    resolution: {integrity: sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==}
 
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
@@ -3085,6 +3174,9 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  process-warning@3.0.0:
+    resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
@@ -3158,6 +3250,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   require-in-the-middle@7.5.2:
     resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
     engines: {node: '>=8.6.0'}
@@ -3178,9 +3274,16 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  ret@0.4.3:
+    resolution: {integrity: sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==}
+    engines: {node: '>=10'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rollup-plugin-esbuild@6.2.1:
     resolution: {integrity: sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA==}
@@ -3213,6 +3316,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex2@3.1.0:
+    resolution: {integrity: sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==}
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -3251,6 +3357,9 @@ packages:
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3389,6 +3498,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -4146,6 +4259,22 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
+
+  '@fastify/ajv-compiler@3.6.0':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
+      fast-uri: 2.4.0
+
+  '@fastify/error@3.4.1': {}
+
+  '@fastify/fast-json-stringify-compiler@4.3.0':
+    dependencies:
+      fast-json-stringify: 5.16.1
+
+  '@fastify/merge-json-schemas@0.1.1':
+    dependencies:
+      fast-deep-equal: 3.1.3
 
   '@grpc/grpc-js@1.13.4':
     dependencies:
@@ -5571,6 +5700,8 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  abstract-logging@2.0.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -5613,12 +5744,27 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
+  ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -5639,6 +5785,11 @@ snapshots:
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
+
+  avvio@8.4.0:
+    dependencies:
+      '@fastify/error': 3.4.1
+      fastq: 1.19.1
 
   axios@1.12.2:
     dependencies:
@@ -6205,7 +6356,11 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-content-type-parse@1.1.0: {}
+
   fast-copy@3.0.2: {}
+
+  fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -6219,11 +6374,48 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@5.16.1:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.1.1
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-deep-equal: 3.1.3
+      fast-uri: 2.4.0
+      json-schema-ref-resolver: 1.0.1
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
 
   fast-redact@3.5.0: {}
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-uri@2.4.0: {}
+
+  fast-uri@3.1.0: {}
+
+  fastify@4.29.1:
+    dependencies:
+      '@fastify/ajv-compiler': 3.6.0
+      '@fastify/error': 3.4.1
+      '@fastify/fast-json-stringify-compiler': 4.3.0
+      abstract-logging: 2.0.1
+      avvio: 8.4.0
+      fast-content-type-parse: 1.1.0
+      fast-json-stringify: 5.16.1
+      find-my-way: 8.2.2
+      light-my-request: 5.14.0
+      pino: 9.9.5
+      process-warning: 3.0.0
+      proxy-addr: 2.0.7
+      rfdc: 1.4.1
+      secure-json-parse: 2.7.0
+      semver: 7.7.2
+      toad-cache: 3.7.0
 
   fastq@1.19.1:
     dependencies:
@@ -6272,6 +6464,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@8.2.2:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 3.1.0
 
   find-up@5.0.0:
     dependencies:
@@ -6560,9 +6758,15 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-ref-resolver@1.0.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+
   json-schema-to-zod@2.6.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-schema-walker@2.0.0:
     dependencies:
@@ -6610,6 +6814,12 @@ snapshots:
       '@libsql/linux-x64-gnu': 0.5.22
       '@libsql/linux-x64-musl': 0.5.22
       '@libsql/win32-x64-msvc': 0.5.22
+
+  light-my-request@5.14.0:
+    dependencies:
+      cookie: 0.7.2
+      process-warning: 3.0.0
+      set-cookie-parser: 2.7.1
 
   local-pkg@1.1.2:
     dependencies:
@@ -6972,6 +7182,8 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  process-warning@3.0.0: {}
+
   process-warning@5.0.0: {}
 
   promise-limit@2.7.0: {}
@@ -7051,6 +7263,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-in-the-middle@7.5.2:
     dependencies:
       debug: 4.4.3
@@ -7071,7 +7285,11 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  ret@0.4.3: {}
+
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.25.9)(rollup@4.50.2):
     dependencies:
@@ -7132,6 +7350,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   safe-buffer@5.2.1: {}
+
+  safe-regex2@3.1.0:
+    dependencies:
+      ret: 0.4.3
 
   safe-stable-stringify@2.5.0: {}
 
@@ -7196,6 +7418,8 @@ snapshots:
       send: 1.2.0
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.1: {}
 
   setprototypeof@1.2.0: {}
 
@@ -7315,6 +7539,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 


### PR DESCRIPTION
## Summary
- add a local filesystem-backed recipe store package and unit tests
- build the recipe workflow service, CLI, and HTTP server endpoints on top of the store
- exercise the workflow end-to-end via integration tests covering generation, promotion, and parsing

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cc1302b354832c8e91acc938cff02e