### PR TITLE
Resolve commander alias for service tests

### DIFF
--- a/apps/service/src/orchestrator/recipe-synthesis.test.ts
+++ b/apps/service/src/orchestrator/recipe-synthesis.test.ts
@@ -36,36 +36,29 @@ describe('buildRecipeFromRuleSet', () => {
     const { recipe } = buildRecipeFromRuleSet({ ruleSet, now });
     const toolset = createFixtureToolset();
     const fixture = loadProductSimpleFixture();
-    const fieldLookup = new Map<RecipeFieldId, FieldRecipe>();
-    recipe.target.fields.forEach((field) => {
-      fieldLookup.set(field.fieldId, field);
-    });
+    const getField = (fieldId: RecipeFieldId): FieldRecipe => {
+      const match = recipe.target.fields.find(
+        (candidate): candidate is FieldRecipe => candidate.fieldId === fieldId
+      );
+      if (!match) {
+        throw new Error(`${fieldId} field missing from recipe`);
+      }
+      return match;
+    };
 
-    const titleField = fieldLookup.get('title');
-    expect(titleField).toBeDefined();
-    if (!titleField) {
-      throw new Error('Title field missing from recipe');
-    }
+    const titleField = getField('title');
     const titleQuery = await toolset.html.query({ selector: titleField.selectorSteps[0].value });
     const titleMatch = titleQuery.matches[0];
     expect(titleMatch).toBeDefined();
     expect(titleMatch?.text.trim()).toBe(fixture.expected.product.title);
 
-    const priceField = fieldLookup.get('price');
-    expect(priceField).toBeDefined();
-    if (!priceField) {
-      throw new Error('Price field missing from recipe');
-    }
+    const priceField = getField('price');
     const priceQuery = await toolset.html.query({ selector: priceField.selectorSteps[0].value });
     const priceMatch = priceQuery.matches[0];
     expect(priceMatch).toBeDefined();
     expect(priceMatch?.text.replace(/\s+/g, ' ').trim()).toContain('149.00');
 
-    const imagesField = fieldLookup.get('images');
-    expect(imagesField).toBeDefined();
-    if (!imagesField) {
-      throw new Error('Images field missing from recipe');
-    }
+    const imagesField = getField('images');
     const imageQuery = await toolset.html.query({ selector: imagesField.selectorSteps[0].value, attribute: 'src' });
     const imageSources = imageQuery.matches.map((match) => {
       const value = match.attributeValue ?? match.attributes.src;
@@ -76,11 +69,7 @@ describe('buildRecipeFromRuleSet', () => {
     });
     expect(imageSources).toEqual(fixture.expected.product.images);
 
-    const breadcrumbField = fieldLookup.get('breadcrumbs');
-    expect(breadcrumbField).toBeDefined();
-    if (!breadcrumbField) {
-      throw new Error('Breadcrumb field missing from recipe');
-    }
+    const breadcrumbField = getField('breadcrumbs');
     const breadcrumbQuery = await toolset.html.query({ selector: breadcrumbField.selectorSteps[0].value });
     const breadcrumbLabels = breadcrumbQuery.matches.map((match) => match.text.replace(/\s+/g, ' ').trim());
     expect(breadcrumbLabels[breadcrumbLabels.length - 1]).toBe('Precision Pour-Over Kettle');

--- a/apps/service/src/recipes/service.ts
+++ b/apps/service/src/recipes/service.ts
@@ -77,9 +77,6 @@ export class RecipeWorkflowService {
 
     const { data: recipe } = parseResult;
 
-    // The recipe has been validated via Zod safeParse, but zod's typings cause
-    // eslint to treat the value as `any` here.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const stored = await this.store.createDraft(recipe, {
       actor: options.actor,
       notes: 'Recipe generated via orchestration.',
@@ -89,7 +86,7 @@ export class RecipeWorkflowService {
     return { stored, orchestration, document };
   }
 
-  async promoteRecipe(id: string, options: PromoteRecipeOptions = {}): Promise<StoredRecipe> {
+  promoteRecipe(id: string, options: PromoteRecipeOptions = {}): Promise<StoredRecipe> {
     return this.store.promote(id, {
       actor: options.actor,
       notes: options.notes ?? 'Promoted via workflow service.',

--- a/apps/service/vitest.config.ts
+++ b/apps/service/vitest.config.ts
@@ -13,7 +13,9 @@ export default defineConfig({
     alias: {
       '@mercator/core': resolve(__dirname, '../../packages/core/src/index.ts'),
       '@mercator/fixtures': resolve(__dirname, '../../packages/fixtures/src/index.ts'),
-      '@mercator/agent-tools': resolve(__dirname, '../../packages/agent-tools/src/index.ts')
+      '@mercator/agent-tools': resolve(__dirname, '../../packages/agent-tools/src/index.ts'),
+      '@mercator/recipe-store': resolve(__dirname, '../../packages/recipe-store/src/index.ts'),
+      commander: resolve(__dirname, '../../node_modules/.pnpm/node_modules/commander/esm.mjs')
     }
   }
 });


### PR DESCRIPTION
## Summary
- point the service Vitest commander alias at the pnpm virtual store so ESM imports resolve
- tighten type usage in the recipe synthesis module to avoid unsafe argument lint failures
- refactor the recipe synthesis test to use a typed field helper instead of mutating a Map

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cc1ba988f8832cad07ec4dd0e6cad5