### PR TITLE
docs: catalog workflow gaps and quality guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Guidelines
+
+These instructions apply to the entire repository. Follow them before submitting changes or marking tasks complete.
+
+## Quality Gates
+
+- Run `pnpm lint` and `pnpm test` locally. Track the effort to get `pnpm typecheck` passing via the backlog and execute it once the blocking debt is closed.
+- Record the command output (or a summary) in the task notes so reviewers can trace the verification.
+- Keep the documentation in sync with the code. When work lands, update the relevant README, roadmap, or task tables within the same PR.
+
+## Coding Practices
+
+- Prefer explicit types and helper functions over `as` casts. If a cast seems necessary, stop and adjust the upstream types (see the backlog tasks on lifecycle history and validation maps).
+- Avoid hard-coding paths into `node_modules/.pnpm`. When a dependency cannot be resolved, add a proper entry point or shim instead of reaching into tool-managed directories.
+- When you touch orchestration logic, enforce budget limits (passes, tool invocations, elapsed time) instead of logging them only for observability.
+
+## Workflow Expectations
+
+- Surface newly discovered debt as follow-up tasks in `docs/tasks/iteration-01-mvp.md` (or the relevant iteration file) rather than hiding it in TODO comments.
+- Cross-link quality findings to `docs/quality/observations.md` so the next agent can quickly understand outstanding risks.
+- For changes that affect the agent workflow, describe the expected end-to-end behavior and remaining gaps in the PR description.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ Additional apps (e.g., `reviewer-ui`) and packages (`core`, `sdk`, `agent-tools`
 - Update task status directly in the task tables when starting or finishing work.
 - Record new architectural choices as ADRs in `docs/decisions/`.
 - Keep documentation synchronized with implemented behavior to minimize churn.
+- Do not mark a task complete until `pnpm lint` and `pnpm test` succeed locally. Track `pnpm typecheck` progress in the backlog and run it once the outstanding TypeScript debt is resolved.
+
+## Current State & Limitations
+
+The repository currently exercises the workflow against the synthetic `product-simple` fixture only. Dynamic URL ingestion,
+rule discovery, and cost-aware budgeting are still open items tracked in the task backlog. CLI and HTTP entrypoints are wired
+to the fixture toolchain, so they require local HTML paths generated from the fixtures. Follow-up work to add live document
+fetching, persisted rule repositories, and stronger budget enforcement is outlined in `docs/tasks/iteration-01-mvp.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,6 @@ This folder captures the stable product vision, architecture, and delivery plan 
 - [Delivery Plan](plan/iterations.md) – iteration roadmap and feature sequencing.
 - [Task Backlog](tasks/index.md) – actionable work items grouped by iteration/feature.
 - [Decisions](decisions/README.md) – architecture decision records (ADRs) for key choices.
+- [Quality Observations](quality/observations.md) – recorded debt, regression history, and workflow gaps.
 
 When adding new documentation, prefer updating the most specific file instead of duplicating information. Link related docs to keep navigation simple for future agents.

--- a/docs/plan/iterations.md
+++ b/docs/plan/iterations.md
@@ -4,7 +4,7 @@ Mercator evolves through thin vertical slices. Each iteration delivers a usable 
 
 | ID | Status  | Focus | Key Outcomes |
 |----|---------|-------|--------------|
-| I01 | Planned | **MVP Product Page Loop** | Agent-assisted recipe generation on synthetic product fixtures, deterministic execution path, CLI/REST thin slice, reviewer workflow stub. |
+| I01 | In Progress | **MVP Product Page Loop** | Fixture-backed orchestration, LocalFS recipe store, CLI/REST thin slice; live URL ingestion and reviewer workflow remain open. |
 | I02 | Planned | **Real Product Pages & Canarying** | Introduce curated live URLs, canary vs stable comparison, budget tracking, improved observability. |
 | I03 | Planned | **Collection Pages & Pagination** | Extend schemas/agents to handle collection cards, pagination sampling, tolerance strategies for partial visibility. |
 | I04 | Planned | **Reviews & Interactivity** | Handle review sections with bounded Playwright plans or API usage, revisit queue for partial sections. |

--- a/docs/quality/observations.md
+++ b/docs/quality/observations.md
@@ -1,0 +1,40 @@
+# Quality & Workflow Observations
+
+This report captures the current state of the documentation, regressions that required emergency fixes, technical debt detected in the codebase, and functional gaps that block the end-to-end agent workflow for live URLs.
+
+## Documentation Review
+
+- **README alignment** – The main README now calls out that the implemented workflow only operates on the synthetic `product-simple` fixture and that dynamic URL ingestion remains future work. Contributors must also record lint/test/typecheck runs before declaring tasks complete.
+- **Iteration status** – Iteration I01 has progressed beyond planning. The roadmap reflects the in-progress state and links to follow-up tasks for missing capabilities such as reviewer tooling and live URL coverage.
+- **Task backlog updates** – The I01 backlog records new follow-up work to enforce orchestration budgets, support URL-driven rule generation, remove brittle Commander aliases, and clean up type casts in the recipe store and validation logic.
+
+## Historical Recovery Work
+
+A review of recent commits highlights recurring error classes:
+
+- **Commander resolution failures** – Tests initially crashed because Vitest could not resolve the `commander` ESM entrypoint. Commit `766b2ed` introduced an alias, and commit `b6a09cd` refined it to the `.pnpm` path. The latter is brittle and tracked as task `I01-F5-T5`.
+- **Linting and type coercion fixes** – Commit `2ae7deb` reintroduced lint compliance by stripping ESLint suppressions and adding helper functions, but it also added `as readonly LifecycleEvent[]` casts around recipe lifecycle history. Task `I01-F5-T6` tracks a typed solution.
+
+Documenting these regressions ensures we do not treat the surface as complete until the underlying issues are resolved.
+
+## Build Health
+
+- `pnpm typecheck` fails today because selector definitions omit defaults (e.g., `all` flags, `metrics`) and several modules import `@mercator/core` via path aliases that TypeScript cannot currently resolve. Tasks `I01-F4-T5` and `I01-F5-T6` track the necessary refactors.
+
+## Code Quality Risks
+
+- **Lifecycle history casts** – `packages/recipe-store/src/local-file-system.ts` uses `as readonly LifecycleEvent[]` to satisfy TypeScript, masking schema drift. Tightening the store contract should remove the casts.
+- **Validation casts** – `apps/service/src/orchestrator/validation.ts` casts extracted values (`title`, `price`, `images`) because the map of results is untyped. Refactoring to return a structured object will surface missing selectors earlier in tests.
+- **Commander alias fragility** – Vitest relies on a `.pnpm`-specific path for `commander`, which will break in environments that do not install dependencies in the same location.
+
+## Agent Workflow Gaps
+
+To support the fully automated workflow (agent receives a URL, refines rules, and executes them without a human-in-the-loop), the following capabilities are still missing:
+
+1. **Live document ingestion** – There is no fetcher for arbitrary URLs. The orchestration service only consumes fixture HTML.
+2. **Rule repository persistence** – Rule sets are hard-coded for the fixture. We need storage that can be updated after an agent session so the execution path can reuse the learned selectors.
+3. **Agent-guided refinement loop** – The orchestration slice skips the agent loop entirely; it reads selectors from the static rule set. Tool invocations need to be driven by agent prompts with checks that respect domain policies.
+4. **Cost and budget enforcement** – While `runAgentOrchestrationSlice` records `AgentBudget`, it never short-circuits passes based on tool counts, elapsed time, or token spend. Without enforcement, the workflow cannot guarantee cost ceilings.
+5. **Agent-free execution endpoint** – The `/parse` endpoint assumes a promoted recipe exists but does not expose a way to request extraction for an arbitrary URL. We need an HTTP surface that accepts a URL, selects the right rule set, executes it, and returns structured data.
+
+The new backlog tasks describe how to close these gaps so the next agent can focus on implementation instead of discovery.

--- a/docs/tasks/iteration-01-mvp.md
+++ b/docs/tasks/iteration-01-mvp.md
@@ -43,14 +43,19 @@ Priority is ascending within each feature. Always complete lower-numbered tasks 
 | 1 | I01-F4-T1 | Define agent context contracts and orchestrator skeleton covering Pass 1–3 with stubbed agents producing ExpectedData and candidate recipe steps. | `packages/core/src/agents/` (interfaces), orchestrator in `apps/service` or shared package, unit tests for control flow. | I01-F2-T2, I01-F3-T2 | Done | refactor: drive orchestrator from rule repository (b68add2). |
 | 2 | I01-F4-T2 | Implement selector recipe synthesis for fixture (map expected fields to CSS selectors, apply transforms/tolerances). | Module producing recipe object, tests verifying selectors match fixture DOM. | I01-F4-T1 | Done | refactor: drive orchestrator from rule repository (b68add2). |
 | 3 | I01-F4-T3 | Implement validator pass computing per-field/document confidence using tolerance helpers and Zod. | Validation module + tests verifying success/failure cases for fixture variations. | I01-F4-T2, I01-F2-T3 | Done | refactor: drive orchestrator from rule repository (b68add2). |
+| 4 | I01-F4-T4 | Enforce orchestration budget and token spend limits before each pass. | Budget tracker that halts passes when limits are exceeded, unit tests covering stop conditions. | I01-F4-T3 | Todo | Current slice records budgets but never checks usage during `runAgentOrchestrationSlice`. |
+| 5 | I01-F4-T5 | Replace untyped field extraction map with structured result object. | Refactor validation utilities to return typed values without `as` casts. | I01-F4-T3 | Todo | `apps/service/src/orchestrator/validation.ts` relies on casts for `title`, `price`, and `images`. |
 
 ### F5. Service, CLI & Recipe Store
 
 | Priority | Task ID | Description | Deliverables | Depends On | Status | Notes |
 |----------|---------|-------------|--------------|------------|--------|-------|
-| 1 | I01-F5-T1 | Implement LocalFS-backed recipe store with versioned state machine (`draft → stable`). | Store module + tests covering save/promote/list. | I01-F2-T2 | Todo | Prepare adapter pattern for future stores. |
-| 2 | I01-F5-T2 | Create REST + CLI endpoints for `/recipes/generate`, `/recipes/promote`, `/parse` wired to orchestrator and recipe store. | Service handlers, CLI commands, integration test hitting fixture path. | I01-F4-T3, I01-F5-T1 | Todo | CLI should call same underlying services to avoid drift. |
+| 1 | I01-F5-T1 | Implement LocalFS-backed recipe store with versioned state machine (`draft → stable`). | Store module + tests covering save/promote/list. | I01-F2-T2 | Done | `packages/recipe-store` provides the adapter but still uses casts around lifecycle history. |
+| 2 | I01-F5-T2 | Create REST + CLI endpoints for `/recipes/generate`, `/recipes/promote`, `/parse` wired to orchestrator and recipe store. | Service handlers, CLI commands, integration test hitting fixture path. | I01-F4-T3, I01-F5-T1 | In Progress | Endpoints exist for fixtures; follow-up tasks cover live URL ingestion and brittle Commander alias resolution. |
 | 3 | I01-F5-T3 | Add reviewer stub endpoint returning tri-pane payload (screenshot, DOM snippet, JSON diff) for HITL. | Endpoint returning deterministic fixture data + placeholder UI data contract. | I01-F5-T2 | Todo | Document UI contract for later implementation. |
+| 4 | I01-F5-T4 | Support live document ingestion and rule persistence for arbitrary URLs. | HTTP fetcher, rule repository updates, and tests covering URL → rule → parse loop without fixtures. | I01-F5-T2 | Todo | Needed to pass an agent a URL and iterate rules without manual fixture wiring. |
+| 5 | I01-F5-T5 | Stabilize Commander resolution for CLI/tests without `.pnpm` path assumptions. | Shared resolver utility or ESM-friendly dependency injection with tests. | I01-F5-T2 | Todo | `apps/service/vitest.config.ts` aliases Commander via `.pnpm`, which breaks on fresh installs. |
+| 6 | I01-F5-T6 | Remove lifecycle history casts from the LocalFS store. | Update store inputs/types so history normalizes without `as readonly LifecycleEvent[]`. | I01-F5-T1 | Todo | Type casts around lifecycle history mask schema regressions in `packages/recipe-store`. |
 
 ### F6. Testing & Observability Baseline
 


### PR DESCRIPTION
## Summary
- document the current fixture-only limitations in the README and mark iteration I01 as in progress
- add a quality observations report plus new backlog tasks for workflow gaps, brittle aliases, and type-safety follow ups
- publish AGENT guidelines covering lint/test verification, documentation hygiene, and casting/budget practices

## Testing
- pnpm lint
- pnpm test
- pnpm typecheck *(fails: existing TypeScript debt tracked in backlog)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3a6a0a08832c8503adb8202bef4c